### PR TITLE
Reach the DME from Android via WebUSB and the FTDI vendor protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,10 @@ than from assumption, whether the identity records are present and which process
 - **Speed**: DME communication defaults to 9600 baud, where a full read takes **~124 s measured** (530 B/s) — about 40 s more than the wire alone accounts for, and that gap is currently unexplained. Faster rates are selectable but **none is reliable yet**: 38400 has both completed and, more recently, timed out 3–10% into a read; 125000 fails outright (the DME accepts the switch, then answers nothing); 57600 / 76800 / 115200 are unconfirmed. If the DME refuses a rate the read silently falls back to 9600, so every read now reports its own elapsed time, throughput and the rate it actually used — otherwise "refused" and "didn't help" look identical. Writes always run at 9600 regardless.
 - **Browser compatibility**:
   - *File workflow*: any Chromium browser (Chrome / Edge / Opera).
-  - *Direct DME workflow*: **Chrome / Edge / Opera desktop only** — it requires the Web Serial API, which Safari does not support and Firefox does not support out of the box.
+  - *Direct DME workflow, desktop*: **Chrome / Edge / Opera** — it requires the Web Serial API, which Safari does not support and Firefox does not support out of the box.
+  - *Direct DME workflow, Android*: **Chrome, with a USB OTG adapter** — and it is **not yet proven on hardware**, see below. Note that Chrome for Android does expose the Web Serial API, but only for Bluetooth serial-port emulation: a USB K+DCAN cable is invisible to it, so the app talks to the cable through WebUSB and the FTDI vendor protocol instead. Genuine FTDI chips only (FT232AM/BM/R); CH340 and other clone cables are not supported on Android.
+  - *Android status*: written, not validated. No phone, cable or car has run it. There is a bench page at **`/usb-check`** that answers the open questions in order — the first being whether Chrome for Android can claim the FTDI interface at all, which everything else depends on. It needs a bare FT232R breakout with TX and RX jumpered together; a K+DCAN cable cannot self-echo on a desk, because its K-line pull-up comes from the car. Run that before trusting the Android path with an ECU.
+  - *Writing from a phone*: supported, and it asks for more care than the desktop path. A write runs 4+ minutes, and if the screen switches off or you switch apps the connection can drop mid-write. The app holds a screen wake lock while writing and warns you before starting, but Android does not let a web page guarantee any of this. If a write does fail it always restarts from the erase, so re-running it is safe.
 - **Live logging caveat**: live values are decoded from the DME's measurement blocks. RPM, relative opening and coolant temperature are confirmed, but the lambda-controller factor used as the STFT input has **not** been cross-checked against a known-good Testo log. Validate it before relying on live-tuned output.
 
 ## Important Note on Development
@@ -251,7 +254,15 @@ Open [http://localhost:5054](http://localhost:5054) with your browser to see the
 saved sessions — pick one and stay on it.
 
 The DME features need a real K+DCAN cable and a secure context; `localhost` counts as secure, so
-`npm run dev` is enough for hardware testing. A **PRACTICE** toggle in the DME panel simulates a DME
+`npm run dev` is enough for hardware testing.
+
+Testing the Android path against a dev server is the one case where that is not enough: a phone
+reaching your machine at `http://192.168.x.x:5054` is **not** a secure context, so both
+`navigator.usb` and `navigator.serial` are simply undefined there and the app will report that it
+cannot reach a DME. Use `adb reverse tcp:5054 tcp:5054` so the phone sees it as its own `localhost`,
+or test against the deployed HTTPS site. Adding `?transport=webusb` forces the WebUSB backend on any
+platform, which is how the FTDI path can be exercised from a desktop bench rig rather than
+first-run in a car (`?transport=webserial` forces the other way). A **PRACTICE** toggle in the DME panel simulates a DME
 so the whole flow (read → live tune → write, plus the flash-counter reset) can be exercised offline
 without a cable. The simulated DME keeps state, so a reset stays reset across re-reads the way a real
 one would.

--- a/docs/implementation-notes.md
+++ b/docs/implementation-notes.md
@@ -35,7 +35,10 @@ src/lib/dme-link/
                         write-response parsing, baud specs, MSS54HP address layout
   identity.ts           System address table, AIF entries, VIN (packed 6-bit), ZIF program number
   liveValueBlocks.ts    Live measurement block field layouts + decoding
-  webSerialTransport.ts navigator.serial wrapper (open/close/reopen/read/write/purge)
+  byteTransport.ts      ByteTransport contract + platform detection + transport factory
+  bufferedByteTransport.ts  Shared receive buffer, parked waiter, readExact (both backends)
+  webSerialTransport.ts navigator.serial wrapper — desktop backend
+  webUsbFtdiTransport.ts    FTDI vendor protocol over WebUSB — Android backend (§14)
   webSerialDmeLink.ts   Real DME implementation (login, read, write, live polling)
   mockDmeLink.ts        Offline simulator — mirrors the real flow incl. phases, no cable needed
 src/lib/checksum/
@@ -339,6 +342,9 @@ Confirmed against the [WICG Web Serial spec](https://wicg.github.io/serial/):
    `getInfo/open/setSignals/getSignals/close/forget` (+ `readable`/`writable`/`connected`).
    No `reconfigure()`/`setOptions()` → **close + reopen is mandatory**. The native reference changes
    baud in place (`FT_SetBaudRate`) and never closes — this is the fundamental gap.
+   *This constraint is specific to Web Serial.* The WebUSB/FTDI backend added for Android issues
+   `SET_BAUD_RATE` on the open handle exactly as the reference does, so it has no port transition at
+   all — see §14.
 2. **Baud rate is unrestricted**: *"A positive, non-zero value…"*. Non-standard rates like 125000 are
    spec-legal, and FTDI computes the divisor for arbitrary rates. **The Windows COM-port dropdown is
    irrelevant** — it only sets a default for apps that don't specify a rate.
@@ -516,6 +522,22 @@ therefore a permanent advantage for native tools. That is wrong. The latency tim
 property of the device*, set in Device Manager → Port Settings → Advanced → Latency Timer, and it
 applies to whichever application opens the port — Chrome included. The only difference is that D2XX
 programs it itself while the VCP path inherits whatever the driver is configured with.
+
+**On the Android/WebUSB backend it is set to 16 — the chip default — and deliberately not lower.**
+Two reasons, and neither is the tail latency this section was originally about:
+
+1. Android has no Device Manager, so nothing sets it for us: without an explicit
+   `SET_LATENCY_TIMER` the device simply runs at its 16 ms default. The call is there to make the
+   value *stated* rather than inherited, not to lower it.
+2. The 2–4 ms prediction above does not transfer. It assumed Web Serial, where the browser process
+   drains the endpoint into the mojo pipe independently of us. On WebUSB **our own read loop is the
+   only thing draining the endpoint, on the same thread as React** — and the chip emits a 2-byte
+   status packet on every timer expiry whether or not it carries data. So the latency timer sets the
+   renderer's idle wakeup rate: 62.5/s at 16 ms, 1000/s at 1 ms. That is precisely the regression
+   the Linux kernel reverted (quoted above), arriving on the main thread instead of in a driver.
+
+The sweep result stands either way: the timer was measured on the car and changed nothing. 8 is the
+only other value worth trying; 1 is not a candidate.
 
 ### Measured on the car (2026-07-28) — and two dead hypotheses
 
@@ -765,6 +787,12 @@ boosted read therefore begins with a port transition that no other DS2 tool prod
 sees it because 9600 sends no switch at all. That matches the failures being exclusive to boosted rates
 and clustered in the first chunks. It cannot be removed, only made less disruptive.
 
+**Update: on the Android/WebUSB backend it *is* removed.** `SET_BAUD_RATE` goes to the open handle,
+the read loop never stops, and DTR/RTS are never re-driven — the app does exactly what the reference
+does. That makes 38400 free to re-test there. It is **not** a prediction that 38400 will now work:
+the FINAL section below rules out this transition along with everything else host-side, and attributes
+the residue to the physical line. Re-test it because it is cheap, not because it is expected.
+
 **Not forced: we never touched DTR/RTS.** The reference explicitly de-asserts both
 (`DtrEnable = false; RtsEnable = false`). We left them at whatever Chromium's `open()` leaves, on every
 open *and* every reopen — so the close/open cycle above was also moving two control lines that, on some
@@ -837,12 +865,19 @@ collection armed only between a read's start and end so it is inert on the flash
 
 ### Out of scope, and why
 
-- **WebUSB + the FTDI vendor protocol.** Technically the closest thing to a D2XX equivalent a browser
-  can reach: the vendor requests for baud divisor, line properties and `SET_LATENCY_TIMER` are all
-  documented and there are (unmaintained) JS implementations. But Chromium claims USB devices on
-  Windows through **WinUSB**, and an FTDI cable is bound to `ftdibus.sys`. Rebinding it with Zadig
-  **removes the COM port**, which breaks INPA / Tool32 / ISTA until it is swapped back. Rejected: the
-  cable has to keep working for everything else.
+- **WebUSB + the FTDI vendor protocol — rejected on Windows, adopted on Android.** Technically the
+  closest thing to a D2XX equivalent a browser can reach: the vendor requests for baud divisor, line
+  properties and `SET_LATENCY_TIMER` are all documented and there are (unmaintained) JS
+  implementations. On **Windows the rejection stands, unchanged**: Chromium claims USB devices there
+  through **WinUSB**, an FTDI cable is bound to `ftdibus.sys`, and rebinding it with Zadig **removes
+  the COM port**, which breaks INPA / Tool32 / ISTA until it is swapped back. The cable has to keep
+  working for everything else, so desktop keeps Web Serial.
+
+  **None of that reasoning reaches Android**, and that is where it now runs (`webUsbFtdiTransport.ts`).
+  There is no `ftdibus.sys` to displace, no COM port to lose, and no INPA/Tool32/ISTA sharing the
+  cable. It is also not a preference there but the only option: **Chrome for Android 138+ does expose
+  `navigator.serial`, but it enumerates only Bluetooth RFCOMM serial-port emulation** — a USB K+DCAN
+  cable never appears in its picker, so Web Serial is present and useless. See §14.
 - **A local native helper** (WebSocket or native-messaging bridge to `ftd2xx.dll`). The only path to
   true D2XX parity. Costs a signed installer, per-OS builds, a firewall prompt, and localhost TLS —
   and FTDI's guidance is that VCP and D2XX cannot be used on one device simultaneously, which would
@@ -890,8 +925,12 @@ CONNECTION → READ → START TUNE → STOP → WRITE ─→ (key off dialog) �
 - **STFT cross-check**: `la_f_regler` vs Testo *Lambdaintegrator* not validated (§8).
 - **Write baud**: write is always 9600 (the reference boosts to 125000 after erase). Deferred until
   baud switching is proven.
-- **Chromium only**: Web Serial is Chrome/Edge/Opera desktop. The file-upload workflow remains the
-  fallback for other browsers and must keep working.
+- **Chromium only**: Chrome/Edge/Opera on desktop (Web Serial), Chrome on Android (WebUSB, §14). The
+  file-upload workflow remains the fallback for every other browser and must keep working.
+- **The Android backend is unproven on hardware.** Every constant in `webUsbFtdiTransport.ts` is
+  derived and asserted, not measured: no phone, no cable and no car have run it yet. `/usb-check` is
+  the bench probe that answers the open questions, and the first one — whether Chrome for Android
+  can claim the interface at all — gates everything else. Treat ❌ as the status until it is run.
 - **IndexedDB is best-effort storage** — the browser can evict it. File download remains the durable
   artifact.
 - **README is stale**: it still says checksum correction is "not yet included" and that flashing is
@@ -1175,3 +1214,116 @@ it faithfully — and answers `readEngineRpm()` with `0`, since a simulator has 
 is separate from `pollLiveMeasurement` on purpose: the mock's ~800 rpm idle is telemetry-shaped test
 data for the datalog to plot, not a claim that something is turning, and one method could not
 honestly serve both questions.
+
+---
+
+## 14. Android — WebUSB and the FTDI vendor protocol
+
+**Status: written and type-checked, proven on nothing.** No phone, no cable and no car have run a
+byte of it. Read §"Verifying it" below before trusting any of it.
+
+### Why WebUSB and not Web Serial
+
+Chrome for Android 138+ *does* expose `navigator.serial`. It is useless here: it enumerates only
+**Bluetooth RFCOMM serial-port emulation**, so a USB K+DCAN cable never appears in its picker. There
+is no feature test that distinguishes the two — the objects are identical and the difference shows
+up as an empty chooser after the user has already tapped through a permission prompt. That is why
+`detectTransportKind()` (`byteTransport.ts`) asks the platform by name, the only place in the app
+that does. `?transport=webusb` / `?transport=webserial` overrides it, which is how the WebUSB path
+can be driven from a desktop bench rig instead of first-run in a car.
+
+The Windows objection in §"Out of scope" is untouched and still governs desktop.
+
+### Structure
+
+`WebSerialTransport` and `WebUsbFtdiTransport` both implement `ByteTransport` and both extend
+`BufferedByteTransport`, which owns the receive buffer, the single parked waiter and `readExact` —
+lifted verbatim out of the Web Serial transport rather than copied, because those semantics are the
+subtlest thing in this layer and a second copy would drift. `WebSerialDmeLink` holds a
+`ByteTransport`; all 21 of its transport calls are unchanged, and the DS2 layer knows nothing about
+which backend it has.
+
+### The constants, and why each is what it is
+
+| Thing | Value | Why |
+|---|---|---|
+| `SET_DATA` | `0x0208` | 8E1. Same load-bearing reason as the Web Serial `parity: 'even'`: DS2's address `0x12` and ACK `0xA0` both have popcount 2, so an 8N1 receiver faults on effectively every frame. |
+| `SET_MODEM_CTRL` | `0x0300` | DTR and RTS both de-asserted (mask bits 8/9 set, state bits 0/1 clear). Equivalent to `setSignals({dataTerminalReady:false, requestToSend:false})`. On some K+DCAN cables these gate the K-line transceiver, so inverted polarity = a cable that works on desktop and is silent on the phone. |
+| `SET_BAUD_RATE` | 9600 → `0x4138`, 38400 → `0xC04E`, 125000 → `0x0018` (index 0) | 3 MHz base, integer divisor plus a 3-bit fractional code: `d8 = 24e6/baud`, `frac = [0,3,2,4,1,5,6,7][d8 & 7]`, `encoded = (d8>>3) | (frac<<14)`. All three are exact — zero baud error. `0x4138` and `0xC04E` match FTDI's published AN232B-05 table, which is the independent check on the derivation. |
+| `SET_LATENCY_TIMER` | 16 | The chip default, stated rather than inherited (Android has no Device Manager to inherit from). **Not lowered** — see the correction in §"The FTDI latency timer". |
+| `SIO_RESET` purge RX | 2 | libftdi ≤1.4 called this 1; libftdi 1.5 deprecated those names and ships `ftdi_tciflush()` using 2, because the old naming had RX and TX swapped. `/usb-check` step 6 tests both values empirically. |
+
+A **three-entry lookup table, not a general converter**: `DS2_SELECTABLE_BAUDS` is exactly these
+three and §9 records why it will not grow. Three audited constants cannot be subtly wrong. The table
+is **recomputed and asserted at module load**, the same convention `ds2.ts` uses for its chunk sizes
+— with no test runner in this project that is the only mechanism that can fail a wrong constant in
+every environment, including production. A wrong divisor here is a garbled write to an ECU.
+
+Chip family is gated on `deviceVersionMajor ∈ {2,4,6}` (FT232AM/BM/R). The H parts and FT-X use a
+12 MHz base and a different index packing, so they are refused by name rather than silently
+mis-clocked.
+
+### The 2-byte status header — the part most likely to go wrong quietly
+
+Every bulk IN **packet** (not every transfer) is prefixed with two bytes: modem status, then a 16550
+line status. With a multi-packet transfer those headers are **interior**, not merely at offset 0.
+Stripping only the leading pair yields a plausible-looking 64 KB BIN with two bytes of garbage every
+64 — a failure that does not announce itself, which is why the acceptance test is a byte-comparison
+against a desktop read of the same ECU rather than "it looked right".
+
+Line-status bits map onto the **error names Web Serial produces**, because `readExact` prints the
+name and §12's triage table is written against those spellings: BI → `BreakError`, FE →
+`FramingError`, PE → `ParityError`, OE → `BufferOverrunError`, device gone → `NetworkError`.
+Priority BI > FE > PE > OE, since a break implies the framing garbage around it. LSR bits are
+latched-since-last-read, so line status is ignored on exactly one packet after open/reopen/recover —
+otherwise recovery immediately re-latches the fault it just repaired.
+
+### What is better here than on Web Serial
+
+- **Baud changes in place.** One `SET_BAUD_RATE`, no close/open, no restarted pump, no control-line
+  movement. This is the "forced" structural difference §9 says cannot be removed.
+- **`purge()` reaches the chip.** It flushes the FTDI's own FIFO, not just the bytes already handed
+  to us. It stays synchronous (fire-and-forget flush) because `resyncTransport` does not await it
+  and `drainUntilQuiet` reads `bufferedLength()` immediately after.
+- **Stopping the pump needs no cancellation.** The status heartbeat resolves the pending
+  `transferIn` within one latency period, so clearing a flag is enough.
+
+### What is worse, and it is a real hazard
+
+With Web Serial the **browser process** drains the endpoint into a 4096-byte mojo pipe independently
+of the renderer. With WebUSB **our read loop is the only thing draining the FT232R's 256-byte RX
+FIFO, on the same thread as React.** At 9600 that is ~267 ms of headroom; a long main-thread stall
+overruns the chip. The mitigation is that it is *detected* — it arrives as OE, latches a
+`BufferOverrunError`, and the existing retry machinery handles it — rather than silently corrupting
+a read. Exactly one transfer is kept in flight; queueing several is the usual throughput trick and
+they almost certainly complete in order, but "almost certainly" reorders a flash payload.
+
+### Long writes on a phone
+
+`beforeunload` is honoured inconsistently on Chrome for Android, so `useUnloadGuard` is weaker there
+and there is no stronger API to reach for. The gap is covered from three sides instead:
+`useScreenWakeLock` removes the interruption that happens by itself (screen inactivity), 
+`useHiddenWitness` records a backgrounding so a failure can name it instead of looking like a cable
+fault, and `writeConfirm` states the extra rules on Android before the write starts.
+
+### Verifying it
+
+`/usb-check` is a standalone bench probe (it imports nothing from the link layer, so it cannot break
+or be broken by what it validates). Use a **bare FT232R breakout with TX–RX jumpered** — a K+DCAN
+cable will not self-echo on a desk, because its K-line pull-up comes from the vehicle on OBD pin 16.
+
+1. Choose + identify — VID/PID and `bcdDevice` (clone chips are common; §12 already says to check).
+2. **Open + `claimInterface`. This is the question that gates the whole project**: if Android's
+   `ftdi_sio` holds the interface and Chrome cannot detach it, none of the rest matters.
+3. Vendor requests both directions (`GET_LATENCY_TIMER` reads back what was set).
+4. Loopback at all three rates — byte-exactness plus elapsed time against theory, which is what
+   catches a wrong divisor.
+5. TX break (`SET_DATA` bit 14) → the BI bit. The only bench-reachable exercise of break recovery.
+6. RX flush polarity, 2 vs 1, measured rather than assumed.
+7. Five-minute endurance with the screen on / off / app-switched / wake-locked — the empirical
+   answer to "does Android freeze the tab mid-flash".
+
+Then, on the car and in this order: identify at 9600 → a full 64 KB read **byte-compared against a
+desktop Web Serial read of the same ECU** (the acceptance test for the status-header design) → a
+datalog → and only then a write. 38400 is free to re-test once reading is proven, but see §9: the
+residual there was attributed to the physical line, not to the port transition this removes.

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -25,6 +25,7 @@ import { saveServiceBackup, listRestorableBackups, loadServiceBackup } from '@/l
 import { beginLiveRun, appendLiveChunk, endLiveRun, discardLiveRun, findRecoverableRun, loadLiveRunPoints } from '@/lib/db/liveRunRepository';
 import { downloadBlob, fileSafe, MIME_BIN, MIME_CSV, MIME_JSON } from '@/lib/download';
 import { dialogText } from '@/lib/dialog-text';
+import { isAndroidPlatform } from '@/lib/dme-link/byteTransport';
 import { serializeLogFile } from '@/lib/log-engine/serializer';
 import { sampleRateHzFromTimes } from '@/lib/log-engine/rate';
 import { sha256Hex } from '@/lib/db/sessionRepository';
@@ -36,6 +37,8 @@ import { useSessionDb } from '@/hooks/useSessionDb';
 import { useFieldVisibility } from '@/hooks/useFieldVisibility';
 import { useDmeLink } from '@/hooks/useDmeLink';
 import { useUnloadGuard } from '@/hooks/useUnloadGuard';
+import { useScreenWakeLock } from '@/hooks/useScreenWakeLock';
+import { useHiddenWitness } from '@/hooks/useHiddenWitness';
 import { useDisclaimer } from '@/hooks/useDisclaimer';
 
 type TabId = 'startup' | 'current' | 'lambda' | 'new' | 'diff' | 'log' | 'warmup' | 'wot';
@@ -232,6 +235,17 @@ export default function Home() {
   // operation that has hung. A data log is a drive: capping it at minutes would drop the guard
   // mid-run, so it gets a bound that only a genuinely stuck state could ever reach.
   useUnloadGuard(unloadGuarded, dmeLink.state === 'tuning' ? 6 * 60 * 60_000 : 10 * 60_000);
+  /**
+   * The two Android-shaped halves of the same problem, deliberately sharing `unloadGuarded` rather
+   * than deriving their own condition — one definition of "an operation that must not be
+   * interrupted", so a state added there cannot be missed here.
+   *
+   * The wake lock removes the failure that happens by itself (screen inactivity timeout mid-write).
+   * The witness cannot prevent anything; it records whether the page was backgrounded, so a failure
+   * can name that instead of looking like a cable fault. Both are no-ops on desktop.
+   */
+  useScreenWakeLock(unloadGuarded);
+  const wasBackgrounded = useHiddenWitness(unloadGuarded);
 
   const [activeTab, setActiveTab] = useState<TabId>('startup');
   /** Bumped by the chart's FIT button. Folded into the plot's uirevision so Plotly drops the
@@ -956,6 +970,10 @@ export default function Home() {
       tuned: Boolean(newMap),
       patchOn: applyPatch || applyWotDisable,
       drift,
+      // Android gets extra lines because the guarantees are weaker there: beforeunload is honored
+      // inconsistently, so the "you will be asked to confirm" sentence above cannot be relied on,
+      // and the screen or an app switch can take the connection down mid-write.
+      android: isAndroidPlatform(),
     }));
     if (!confirmed) return;
 
@@ -1039,7 +1057,7 @@ export default function Home() {
       // notice line and a WRITE button that still looked ready. That is the most consequential moment
       // in the app to stay silent about: writePartialBin erases the data area BEFORE it writes, so a
       // failure part-way through can leave the ECU partially programmed.
-      alert(dialogText().writeFailed(dmeLink.error));
+      alert(dialogText().writeFailed(dmeLink.error, { wasBackgrounded: wasBackgrounded() }));
     }
   };
 
@@ -1338,7 +1356,12 @@ export default function Home() {
   const derivedTablesLockReason = 'Needs a tune first — these tables are derived from the tuned map. Record a log (START TUNE) or load one, then they unlock.';
 
   return (
-    <main className="h-screen flex flex-col bg-slate-950 font-sans text-slate-300 overflow-hidden selection:bg-blue-500/30">
+    // 100dvh, not h-screen. This page deliberately never scrolls — everything is sized to fit the
+    // viewport — and on Android `100vh` resolves to the LARGEST viewport, the one with the browser
+    // chrome retracted. With no scrolling to recover it, the bottom of the layout (the action row
+    // that carries WRITE) sits under the URL bar and cannot be reached. `dvh` tracks the viewport
+    // that is actually visible.
+    <main className="h-[100dvh] flex flex-col bg-slate-950 font-sans text-slate-300 overflow-hidden selection:bg-blue-500/30">
       {/* App Header - Ultra Minimal */}
       <header className="relative px-6 py-3 flex justify-between items-center bg-slate-950/80 backdrop-blur-md z-10 shrink-0 h-[48px]">
         {/* The ///M stripe as the header's bottom rule, replacing a slate-900 border-b. Absolutely
@@ -1369,10 +1392,16 @@ export default function Home() {
             TUNER
           </h1>
           <span className="shrink-0 text-[9px] font-mono text-slate-500 whitespace-nowrap">V2 β</span>
-          <div className="flex-1 min-w-0 flex items-center gap-4 text-[9px] font-mono text-slate-500 whitespace-nowrap overflow-hidden ml-8 pl-8 border-l border-slate-800">
-            <span>VIN <span className="text-slate-300">{dmeLink.identity?.vin ?? '-'}</span></span>
-            <span>AIF <span className="text-slate-300">{dmeLink.identity?.aif ?? '-'}</span></span>
-            <span>SW <span className="text-slate-300">{dmeLink.identity?.softwareVersion ?? '-'}</span></span>
+          {/* VIN/AIF/SW are readouts and may clip; FLASH is a control and may not — it is the only
+              entry to the flash-counter dialog, so clipping it removes a feature rather than a
+              label. Below 900px (where the panes stack, i.e. phones) the three readouts are hidden
+              outright and FLASH keeps its place, instead of all four being squeezed until the
+              button falls off the end of an overflow-hidden row. The identity is still on the
+              status dot's tooltip, and the readouts return the moment there is room. */}
+          <div className="flex-1 min-w-0 flex items-center gap-4 text-[9px] font-mono text-slate-500 whitespace-nowrap overflow-hidden ml-2 min-[900px]:ml-8 pl-2 min-[900px]:pl-8 border-l border-slate-800">
+            <span className="hidden min-[900px]:inline">VIN <span className="text-slate-300">{dmeLink.identity?.vin ?? '-'}</span></span>
+            <span className="hidden min-[900px]:inline">AIF <span className="text-slate-300">{dmeLink.identity?.aif ?? '-'}</span></span>
+            <span className="hidden min-[900px]:inline">SW <span className="text-slate-300">{dmeLink.identity?.softwareVersion ?? '-'}</span></span>
             {/* The only one of the four that is a control: clicking it opens the reset dialog. The
                 reset has no button of its own anywhere else — it belongs on the number it changes,
                 and the hub's sub-action row is for actions on the workspace and the current run.
@@ -1932,10 +1961,15 @@ export default function Home() {
                 <div className="h-[14px] px-2 flex items-center overflow-hidden">
                   {(() => {
                     // dmeLink.warning first: it describes the operation that just ran, and the
-                    // Web Serial notice only applies while disconnected, so the two never compete.
+                    // transport notice only applies while disconnected, so the two never compete.
+                    //
+                    // `transportKind === 'none'` rather than a negated "supported" flag, because
+                    // null (not yet determined, i.e. the static prerender) must render nothing.
+                    // The old test was a bare boolean that read false during prerender, which put
+                    // an "unsupported browser" line into the exported HTML for every visitor.
                     const warning = dmeLink.warning
-                      ?? (!dmeLink.mockMode && dmeLink.state === 'disconnected' && !dmeLink.isWebSerialSupported
-                        ? 'Web Serial API not available in this browser — use Chrome/Edge, or check PRACTICE to test offline.'
+                      ?? (!dmeLink.mockMode && dmeLink.state === 'disconnected' && dmeLink.transportKind === 'none'
+                        ? dialogText().noTransport({ android: isAndroidPlatform() })
                         : null);
                     const notice = dmeLink.error ?? warning;
                     if (!notice) return null;
@@ -2146,6 +2180,12 @@ export default function Home() {
                   box. Laid out horizontally the content is 31px tall whatever it holds, and the
                   reserved height is untouched so the hub still cannot move. No flex-wrap: a second
                   line would put the height back over budget, which is the bug this fixes. */}
+              {/* The buttons below carry `py-3 -my-3`: the padding grows the touch target to ~40px
+                  while the negative margin cancels its contribution to layout, so the 31px content
+                  height and the 46px budget above are both exactly as measured. Finger-sized targets
+                  matter here more than anywhere else in the app — Discard log throws away a drive
+                  and Reset Adapt writes to the ECU — and on a phone a 15px-tall button between two
+                  siblings 16px away is a coin toss. Do not "simplify" this to plain padding. */}
               <div className="h-[46px] flex-none flex flex-row items-center justify-center gap-x-4">
                 {dmeLink.transferPhase && (
                   <span className={`whitespace-nowrap text-[9px] font-bold tracking-[0.2em] uppercase animate-pulse ${transferStyle.text}`}>
@@ -2165,7 +2205,7 @@ export default function Home() {
                 {processedLog && !isArchived && dmeLink.state !== 'tuning' && dmeLink.state !== 'writing' && (
                   <button
                     onClick={handleDiscardLog}
-                    className="whitespace-nowrap flex items-center gap-1.5 text-[10px] font-bold uppercase tracking-widest text-slate-500 hover:text-red-400 transition-colors"
+                    className="whitespace-nowrap flex items-center gap-1.5 py-3 -my-3 text-[10px] font-bold uppercase tracking-widest text-slate-500 hover:text-red-400 transition-colors"
                   >
                     <RotateCcw className="w-3 h-3" /> Discard log
                   </button>
@@ -2187,7 +2227,7 @@ export default function Home() {
                 {dmeLink.state === 'connected' && (idleAction === 'tune' || activeTab === 'startup') && (
                   <button
                     onClick={() => setAdaptDialogOpen(true)}
-                    className="whitespace-nowrap flex items-center gap-1.5 text-[10px] font-bold uppercase tracking-widest text-slate-500 hover:text-amber-400 transition-colors"
+                    className="whitespace-nowrap flex items-center gap-1.5 py-3 -my-3 text-[10px] font-bold uppercase tracking-widest text-slate-500 hover:text-amber-400 transition-colors"
                   >
                     <Eraser className="w-3 h-3" /> Reset Adapt
                   </button>
@@ -2203,7 +2243,7 @@ export default function Home() {
                 {dmeLink.state === 'reading' && (
                   <button
                     onClick={dmeLink.cancelRead}
-                    className="whitespace-nowrap flex items-center gap-1.5 text-[10px] font-bold uppercase tracking-widest text-slate-500 hover:text-red-400 transition-colors"
+                    className="whitespace-nowrap flex items-center gap-1.5 py-3 -my-3 text-[10px] font-bold uppercase tracking-widest text-slate-500 hover:text-red-400 transition-colors"
                   >
                     <Square className="w-3 h-3" /> Cancel Read
                   </button>

--- a/src/app/usb-check/page.tsx
+++ b/src/app/usb-check/page.tsx
@@ -1,0 +1,294 @@
+'use client';
+
+import React from 'react';
+import { FTDI_DATA_8E1_TX_BREAK } from '@/lib/dme-link/webUsbFtdiTransport';
+
+/**
+ * A bench probe for the WebUSB/FTDI path — deliberately standalone.
+ *
+ * The whole Android port rests on one question that no amount of code review can answer: can Chrome
+ * for Android actually claim the interface on this phone, with this cable? If the kernel's
+ * `ftdi_sio` holds it, or OTG will not supply VBUS, everything else is wasted work. So this page
+ * exists to answer that first, and it imports nothing from the link layer — it cannot be broken by,
+ * or break, the transport it is used to validate.
+ *
+ * It also covers the things a car cannot be used to test safely: whether the divisor constants
+ * produce the baud rates they claim, whether a break is really visible as the BI bit, whether the
+ * RX flush value is 2 and not 1, and whether a backgrounded tab survives four minutes.
+ *
+ * Everything logs on-screen because a phone has no console.
+ *
+ * **Bench wiring:** use a bare FT232R breakout with TX and RX jumpered together. A K+DCAN cable
+ * will *not* self-echo on a desk — the K-line pull-up comes from the vehicle (OBD pin 16), so with
+ * no car attached there is nothing to echo. Do not plug into a car for any of this.
+ */
+
+const FTDI_VENDOR_ID = 0x0403;
+const SIO_RESET = 0x00;
+const SIO_SET_MODEM_CTRL = 0x01;
+const SIO_SET_FLOW_CTRL = 0x02;
+const SIO_SET_BAUD_RATE = 0x03;
+const SIO_SET_DATA = 0x04;
+const SIO_SET_LATENCY_TIMER = 0x09;
+const SIO_GET_LATENCY_TIMER = 0x0A;
+const PORT = 1;
+
+const DIVISORS: Record<number, { value: number; index: number }> = {
+    9600: { value: 0x4138, index: 0 },
+    38400: { value: 0xC04E, index: 0 },
+    125000: { value: 0x0018, index: 0 },
+};
+
+const CHIP_NAMES: Record<number, string> = {
+    2: 'FT232AM', 4: 'FT232BM', 5: 'FT2232C', 6: 'FT232R',
+    7: 'FT2232H', 8: 'FT4232H', 9: 'FT232H', 16: 'FT-X',
+};
+
+export default function UsbCheckPage() {
+    const [lines, setLines] = React.useState<string[]>([]);
+    const [busy, setBusy] = React.useState(false);
+    const deviceRef = React.useRef<USBDevice | null>(null);
+    const epRef = React.useRef({ inEp: 0, outEp: 0, packetSize: 64, iface: 0 });
+
+    const log = React.useCallback((text: string) => {
+        setLines(prev => [...prev, text]);
+    }, []);
+
+    const run = (label: string, fn: () => Promise<void>) => async () => {
+        setBusy(true);
+        log(`\n=== ${label} ===`);
+        try { await fn(); }
+        catch (e: unknown) {
+            const err = e as Error;
+            log(`✗ ${err?.name ?? 'Error'}: ${err?.message ?? String(e)}`);
+        }
+        finally { setBusy(false); }
+    };
+
+    const device = () => {
+        const d = deviceRef.current;
+        if (!d) throw new Error('No device — run step 1 first');
+        return d;
+    };
+
+    const sio = async (request: number, value: number, index = PORT) => {
+        const r = await device().controlTransferOut({
+            requestType: 'vendor', recipient: 'device', request, value, index,
+        });
+        if (r.status !== 'ok') throw new Error(`control 0x${request.toString(16)} -> ${r.status}`);
+    };
+
+    // --- 1. choose + identify -------------------------------------------------
+    const step1 = run('1. Choose device', async () => {
+        if (!navigator.usb) { log('✗ navigator.usb is undefined — WebUSB unavailable'); return; }
+        const granted = (await navigator.usb.getDevices()).filter(d => d.vendorId === FTDI_VENDOR_ID);
+        if (granted.length) log(`(${granted.length} device already granted to this origin)`);
+        const d = granted[0] ?? await navigator.usb.requestDevice({ filters: [{ vendorId: FTDI_VENDOR_ID }] });
+        deviceRef.current = d;
+        const major = d.deviceVersionMajor;
+        log(`✓ VID 0x${d.vendorId.toString(16).padStart(4, '0')} PID 0x${d.productId.toString(16).padStart(4, '0')}`);
+        log(`  bcdDevice ${major}.${d.deviceVersionMinor} -> ${CHIP_NAMES[major] ?? 'UNKNOWN'}`);
+        log(`  manufacturer: ${d.manufacturerName ?? '-'}`);
+        log(`  product:      ${d.productName ?? '-'}`);
+        log(`  serial:       ${d.serialNumber ?? '-'}`);
+        if (![2, 4, 6].includes(major)) {
+            log('  ⚠ This chip family uses a different clock/divisor encoding than the transport implements.');
+        }
+        if (d.manufacturerName && !/ftdi/i.test(d.manufacturerName)) {
+            log('  ⚠ Manufacturer string is not FTDI — possible clone. Clone chips are common on K+DCAN cables.');
+        }
+    });
+
+    // --- 2. THE question: claim ----------------------------------------------
+    const step2 = run('2. Open + claim interface', async () => {
+        const d = device();
+        await d.open();
+        log('✓ open()');
+        if (!d.configuration) { await d.selectConfiguration(1); log('✓ selectConfiguration(1)'); }
+        for (const iface of d.configuration?.interfaces ?? []) {
+            log(`  interface ${iface.interfaceNumber} (claimed=${iface.claimed})`);
+            for (const ep of iface.alternate.endpoints) {
+                log(`    ep ${ep.endpointNumber} ${ep.direction} ${ep.type} packetSize=${ep.packetSize}`);
+            }
+            const inEp = iface.alternate.endpoints.find(e => e.direction === 'in' && e.type === 'bulk');
+            const outEp = iface.alternate.endpoints.find(e => e.direction === 'out' && e.type === 'bulk');
+            if (inEp && outEp) {
+                epRef.current = {
+                    inEp: inEp.endpointNumber, outEp: outEp.endpointNumber,
+                    packetSize: inEp.packetSize || 64, iface: iface.interfaceNumber,
+                };
+            }
+        }
+        await d.claimInterface(epRef.current.iface);
+        log(`✓ claimInterface(${epRef.current.iface}) — THIS IS THE ONE THAT MATTERS`);
+        log('  If you got here, Chrome detached any kernel driver and the port is viable.');
+    });
+
+    // --- 3. vendor requests, both directions ---------------------------------
+    const step3 = run('3. Vendor requests', async () => {
+        await sio(SIO_RESET, 0); log('✓ SIO_RESET(0)');
+        await sio(SIO_SET_LATENCY_TIMER, 16); log('✓ SET_LATENCY_TIMER(16)');
+        await sio(SIO_SET_FLOW_CTRL, 0, 0x0000 | PORT); log('✓ SET_FLOW_CTRL(none)');
+        await sio(SIO_SET_BAUD_RATE, DIVISORS[9600].value, DIVISORS[9600].index); log('✓ SET_BAUD_RATE(9600)');
+        await sio(SIO_SET_DATA, 0x0208); log('✓ SET_DATA(8E1 = 0x0208)');
+        await sio(SIO_SET_MODEM_CTRL, 0x0300); log('✓ SET_MODEM_CTRL(DTR low, RTS low = 0x0300)');
+        const back = await device().controlTransferIn({
+            requestType: 'vendor', recipient: 'device', request: SIO_GET_LATENCY_TIMER, value: 0, index: PORT,
+        }, 1);
+        const got = back.data?.getUint8(0);
+        log(got === 16
+            ? '✓ GET_LATENCY_TIMER read back 16 — control transfers work both ways'
+            : `⚠ GET_LATENCY_TIMER returned ${got} (expected 16)`);
+    });
+
+    /** Reads until `want` payload bytes have arrived or the deadline passes, stripping the 2-byte
+     *  status header from every packet. Returns payload plus any line-status faults seen. */
+    const readPayload = async (want: number, timeoutMs: number) => {
+        const { inEp, packetSize } = epRef.current;
+        const out: number[] = [];
+        let lsrSeen = 0;
+        const deadline = Date.now() + timeoutMs;
+        while (out.length < want && Date.now() < deadline) {
+            const r = await device().transferIn(inEp, 8 * packetSize);
+            const view = r.data;
+            if (!view) continue;
+            for (let off = 0; off + 2 <= view.byteLength; off += packetSize) {
+                lsrSeen |= view.getUint8(off + 1);
+                const n = Math.min(packetSize, view.byteLength - off) - 2;
+                for (let i = 0; i < n; i++) out.push(view.getUint8(off + 2 + i));
+            }
+        }
+        return { bytes: out, lsrSeen };
+    };
+
+    // --- 4. loopback at each rate --------------------------------------------
+    const step4 = run('4. Loopback (needs TX-RX jumper)', async () => {
+        for (const baud of [9600, 38400, 125000]) {
+            await sio(SIO_SET_BAUD_RATE, DIVISORS[baud].value, DIVISORS[baud].index);
+            await sio(SIO_RESET, 2); // purge RX
+            const pattern = new Uint8Array(1024);
+            for (let i = 0; i < pattern.length; i++) pattern[i] = i & 0xFF;
+            const t0 = performance.now();
+            await device().transferOut(epRef.current.outEp, pattern);
+            const { bytes, lsrSeen } = await readPayload(pattern.length, 10_000);
+            const elapsed = performance.now() - t0;
+            // 8E1 is 11 bits per byte on the wire.
+            const theory = (pattern.length * 11 * 1000) / baud;
+            const exact = bytes.length === pattern.length && bytes.every((b, i) => b === pattern[i]);
+            log(`${exact ? '✓' : '✗'} ${baud}: ${bytes.length}/${pattern.length} bytes, ` +
+                `${elapsed.toFixed(0)} ms (theory ${theory.toFixed(0)} ms), lsr=0x${lsrSeen.toString(16)}`);
+            if (!exact && bytes.length) {
+                const bad = bytes.findIndex((b, i) => b !== pattern[i]);
+                log(`   first mismatch at ${bad}: got 0x${bytes[bad]?.toString(16)} want 0x${pattern[bad]?.toString(16)}`);
+            }
+            // A wrong divisor shows up as garbage, or as an elapsed time far from theory.
+            if (elapsed > theory * 2.5) log('   ⚠ far slower than theory — suspect a wrong divisor');
+        }
+        await sio(SIO_SET_BAUD_RATE, DIVISORS[9600].value, DIVISORS[9600].index);
+    });
+
+    // --- 5. break generation + detection --------------------------------------
+    const step5 = run('5. TX break -> BI bit (needs jumper)', async () => {
+        await sio(SIO_SET_BAUD_RATE, DIVISORS[9600].value, DIVISORS[9600].index);
+        await sio(SIO_RESET, 2);
+        await sio(SIO_SET_DATA, FTDI_DATA_8E1_TX_BREAK);
+        await new Promise(r => setTimeout(r, 50));
+        await sio(SIO_SET_DATA, 0x0208);
+        const { lsrSeen } = await readPayload(1, 1500);
+        log((lsrSeen & 0x10)
+            ? '✓ BI (0x10) observed — break detection works, so recoverRead has something to react to'
+            : `✗ no BI bit; lsr=0x${lsrSeen.toString(16)}. Break recovery would be untested/dark.`);
+    });
+
+    // --- 6. RX flush polarity --------------------------------------------------
+    const step6 = run('6. RX flush polarity (1 vs 2)', async () => {
+        for (const value of [2, 1]) {
+            await sio(SIO_SET_BAUD_RATE, DIVISORS[9600].value, DIVISORS[9600].index);
+            await sio(SIO_RESET, 2);
+            await device().transferOut(epRef.current.outEp, new Uint8Array([0xAA, 0x55, 0xAA, 0x55]));
+            await new Promise(r => setTimeout(r, 300)); // let them land in the chip's FIFO
+            await sio(SIO_RESET, value);
+            const { bytes } = await readPayload(4, 600);
+            log(`SIO_RESET(${value}): ${bytes.length} byte(s) survived the flush ` +
+                `${bytes.length === 0 ? '-> this value flushes RX' : ''}`);
+        }
+    });
+
+    // --- 7. endurance / backgrounding -----------------------------------------
+    const step7 = run('7. 5-minute endurance (background the app during this)', async () => {
+        await sio(SIO_SET_BAUD_RATE, DIVISORS[9600].value, DIVISORS[9600].index);
+        let wakeLock: WakeLockSentinel | null = null;
+        try { wakeLock = (await navigator.wakeLock?.request('screen')) ?? null; log('wake lock acquired'); }
+        catch { log('wake lock unavailable'); }
+        let hidden = false;
+        const onVis = () => { if (document.visibilityState === 'hidden') hidden = true; };
+        document.addEventListener('visibilitychange', onVis);
+        const end = Date.now() + 5 * 60_000;
+        let maxGap = 0, rounds = 0, errors = 0;
+        let last = performance.now();
+        try {
+            while (Date.now() < end) {
+                try {
+                    await device().transferOut(epRef.current.outEp, new Uint8Array([0x00]));
+                    await readPayload(1, 2000);
+                } catch { errors++; }
+                const now = performance.now();
+                maxGap = Math.max(maxGap, now - last);
+                last = now;
+                if (++rounds % 200 === 0) log(`  ${rounds} rounds, max gap ${maxGap.toFixed(0)} ms, ${errors} errors`);
+            }
+        } finally {
+            document.removeEventListener('visibilitychange', onVis);
+            await wakeLock?.release().catch(() => { });
+        }
+        log(`done: ${rounds} rounds, max gap ${maxGap.toFixed(0)} ms, ${errors} errors, backgrounded=${hidden}`);
+        log(maxGap > 10_000
+            ? '⚠ A gap over 10 s means the tab was frozen — a 4-minute flash is at risk on this device.'
+            : '✓ No long freeze observed.');
+    });
+
+    const close = run('Close', async () => {
+        try { await deviceRef.current?.releaseInterface(epRef.current.iface); } catch { }
+        await deviceRef.current?.close();
+        deviceRef.current = null;
+        log('✓ closed');
+    });
+
+    const buttons: Array<[string, () => void]> = [
+        ['1. Choose', step1], ['2. Claim', step2], ['3. Vendor', step3],
+        ['4. Loopback', step4], ['5. Break', step5], ['6. Flush', step6],
+        ['7. Endurance', step7], ['Close', close],
+    ];
+
+    return (
+        <main className="min-h-[100dvh] bg-slate-950 text-slate-300 font-mono text-xs p-4">
+            <h1 className="text-sm font-bold tracking-widest uppercase mb-1">WebUSB / FTDI bench probe</h1>
+            <p className="text-[11px] text-slate-500 mb-3">
+                Bare FT232R breakout with TX–RX jumpered. Not a car, and not a K+DCAN cable on a desk —
+                its K-line pull-up comes from the vehicle, so it cannot self-echo.
+            </p>
+            <div className="flex flex-wrap gap-2 mb-3">
+                {buttons.map(([label, onClick]) => (
+                    <button
+                        key={label}
+                        onClick={onClick}
+                        disabled={busy}
+                        className="px-3 py-2 min-h-[44px] border border-slate-700 rounded bg-slate-900
+                                   hover:border-slate-500 disabled:opacity-40 text-[11px] font-bold tracking-wider"
+                    >
+                        {label}
+                    </button>
+                ))}
+                <button
+                    onClick={() => setLines([])}
+                    className="px-3 py-2 min-h-[44px] border border-slate-800 rounded text-slate-500 text-[11px]"
+                >
+                    Clear
+                </button>
+            </div>
+            <pre className="whitespace-pre-wrap break-words leading-relaxed border-t border-slate-800 pt-3">
+                {lines.join('\n') || 'Ready.'}
+            </pre>
+        </main>
+    );
+}

--- a/src/components/DialogFrame.tsx
+++ b/src/components/DialogFrame.tsx
@@ -11,12 +11,19 @@ import { X } from 'lucide-react';
  * is at that moment erasing a vehicle's identity records, a dialog that jumps around while it works
  * reads as something going wrong.
  *
- * So the height is stated here, not derived: `min(84vh,560px)`, with the viewport cap kept so a short
+ * So the height is stated here, not derived: `min(84dvh,560px)`, with the viewport cap kept so a short
  * laptop screen still fits. 560 is the tallest arrangement either dialog needs — the twelve-row
  * adaptation table under its confirmation warnings — measured at 0 px of overflow in Japanese and
  * 32 px in English, where the longer labels wrap. Content that outgrows it scrolls inside the body;
  * the frame does not react to it. Both dialogs share the number deliberately: they open from
  * adjacent header buttons, and one box in one place is easier to trust than two that nearly match.
+ *
+ * **The width cap does not weaken any of that.** `min(560px, 100vw-2rem)` still resolves to one
+ * number for the dialog's whole lifetime — the viewport does not change while a dialog is open — so
+ * the box is as fixed as it ever was. What it fixes is a phone: at 560 px flat, every portrait
+ * handset clipped both edges off the dialog, including its buttons. `dvh` rather than `vh` for the
+ * same reason as the app shell: on Android `vh` is the *largest* viewport, so 84vh could reach
+ * under the browser's own chrome.
  */
 interface FrameProps {
     /** Rendered at the title's left, sized by the caller (`w-3 h-3`). */
@@ -39,7 +46,7 @@ export const DialogFrame: React.FC<FrameProps> = ({ icon, title, closeLabel, onC
             className="fixed inset-0 z-[100] bg-slate-950/70 backdrop-blur-sm"
             onClick={onClose}
         />
-        <div className="fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-[560px] h-[min(84vh,560px)] flex flex-col bg-slate-900 border border-slate-700 rounded-lg shadow-xl z-[110] p-4 animate-in fade-in zoom-in-95 duration-200">
+        <div className="fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-[min(560px,calc(100vw-2rem))] h-[min(84dvh,560px)] flex flex-col bg-slate-900 border border-slate-700 rounded-lg shadow-xl z-[110] p-4 animate-in fade-in zoom-in-95 duration-200">
             <div className="flex justify-between items-center mb-4 border-b border-slate-800 pb-2 shrink-0">
                 <h3 className="text-xs font-bold text-slate-300 uppercase tracking-widest flex items-center gap-2">
                     {icon}

--- a/src/components/DisclaimerDialog.tsx
+++ b/src/components/DisclaimerDialog.tsx
@@ -60,7 +60,11 @@ export const DisclaimerDialog: React.FC<Props> = ({ onAccept }) => {
                 role="dialog"
                 aria-modal="true"
                 aria-labelledby="disclaimer-title"
-                className="fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-[560px] max-h-[80vh] flex flex-col bg-slate-900 border border-slate-700 rounded-lg shadow-xl z-[110] p-4 animate-in fade-in zoom-in-95 duration-200"
+                // Same geometry rule as DialogFrame: capped to the viewport so a portrait phone does
+                // not lose the ACCEPT button off the edge, and dvh so Android's browser chrome does
+                // not sit on top of it. This is the gate to the whole app — if it does not fit, the
+                // app does not open.
+                className="fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-[min(560px,calc(100vw-2rem))] max-h-[85dvh] flex flex-col bg-slate-900 border border-slate-700 rounded-lg shadow-xl z-[110] p-4 animate-in fade-in zoom-in-95 duration-200"
             >
                 <div className="flex items-center gap-2 mb-4 border-b border-slate-800 pb-2 shrink-0">
                     <AlertTriangle className="w-3.5 h-3.5 text-red-400" />

--- a/src/components/LogTimeSeriesChart.tsx
+++ b/src/components/LogTimeSeriesChart.tsx
@@ -239,9 +239,70 @@ export const LogTimeSeriesChart = React.memo(function LogTimeSeriesChart({
             if (!frame) frame = requestAnimationFrame(apply);
         };
 
+        /**
+         * The same gesture for a finger.
+         *
+         * A touch drag emits no wheel event, so on a touchscreen the handler above never ran — and
+         * because Plotly's dragmode is 'pan', the drag fell through to Plotly and panned the
+         * chart's own x-range. That is precisely the desync this whole effect exists to prevent:
+         * the chart moves, the row table beside it goes on showing a different slice, and clicking
+         * a point stops jumping to its row. So touch was not merely unsupported here, it actively
+         * defeated the protection. Routing pointer drags into the same `apply()` restores the rule
+         * the comment above states — one window, both views, one gesture.
+         *
+         * Horizontal-dominant only, decided once per gesture from the first few pixels, because a
+         * vertical drag on a phone is a page gesture and a diagonal one should not steal it. Sign
+         * is inverted against the wheel: dragging content right moves the window left.
+         *
+         * Pointer events rather than touch events so a stylus and a mouse drag behave identically;
+         * `pointerType === 'mouse'` is skipped because a mouse already has the wheel, and
+         * intercepting its drag would take Plotly's own box-pan away.
+         */
+        let tracking = false;
+        let decided: 'horizontal' | 'vertical' | null = null;
+        let lastX = 0, startX = 0, startY = 0, pointerId = -1;
+
+        const onPointerDown = (e: PointerEvent) => {
+            if (e.pointerType === 'mouse' || !e.isPrimary) return;
+            tracking = true; decided = null; pointerId = e.pointerId;
+            startX = lastX = e.clientX; startY = e.clientY;
+        };
+
+        const onPointerMove = (e: PointerEvent) => {
+            if (!tracking || e.pointerId !== pointerId) return;
+            if (decided === null) {
+                const dx = Math.abs(e.clientX - startX), dy = Math.abs(e.clientY - startY);
+                if (dx < 6 && dy < 6) return;          // below the slop threshold, no verdict yet
+                decided = dx > dy ? 'horizontal' : 'vertical';
+                if (decided === 'horizontal') wrapper.setPointerCapture(e.pointerId);
+            }
+            if (decided !== 'horizontal') return;
+            e.preventDefault();
+            e.stopPropagation();
+            pendingPx -= e.clientX - lastX;            // drag right → window left, as the wheel does
+            lastX = e.clientX;
+            if (!frame) frame = requestAnimationFrame(apply);
+        };
+
+        const endPointer = (e: PointerEvent) => {
+            if (e.pointerId !== pointerId) return;
+            if (decided === 'horizontal' && wrapper.hasPointerCapture(e.pointerId)) {
+                wrapper.releasePointerCapture(e.pointerId);
+            }
+            tracking = false; decided = null; pointerId = -1;
+        };
+
         wrapper.addEventListener('wheel', onWheel, { capture: true, passive: false });
+        wrapper.addEventListener('pointerdown', onPointerDown, { capture: true });
+        wrapper.addEventListener('pointermove', onPointerMove, { capture: true, passive: false });
+        wrapper.addEventListener('pointerup', endPointer, { capture: true });
+        wrapper.addEventListener('pointercancel', endPointer, { capture: true });
         return () => {
             wrapper.removeEventListener('wheel', onWheel, { capture: true });
+            wrapper.removeEventListener('pointerdown', onPointerDown, { capture: true });
+            wrapper.removeEventListener('pointermove', onPointerMove, { capture: true });
+            wrapper.removeEventListener('pointerup', endPointer, { capture: true });
+            wrapper.removeEventListener('pointercancel', endPointer, { capture: true });
             if (frame) cancelAnimationFrame(frame);
         };
     }, [onPanWindow, canPanWindow, data]);
@@ -386,7 +447,11 @@ export const LogTimeSeriesChart = React.memo(function LogTimeSeriesChart({
     return (
         <div
             ref={wrapperRef}
-            className="w-full h-full min-h-[300px]"
+            // touch-action: pan-y. Without it the browser claims a horizontal drag as a scroll or a
+            // back-navigation gesture before pointermove is ever delivered, so the window pan below
+            // could never start. `pan-y` gives up only the axis this chart does not use, leaving a
+            // vertical swipe as the ordinary page gesture it should be.
+            className="w-full h-full min-h-[300px] touch-pan-y"
             onClick={(e) => {
                 if (onPointClick) {
                     // [FIX] Global Bounds Check first: Ignore clicks in margins (Legend, X-Axis)

--- a/src/hooks/useDmeLink.ts
+++ b/src/hooks/useDmeLink.ts
@@ -6,7 +6,7 @@ import {
 import { ServiceBlockReport, buildServiceBlockReport } from '@/lib/dme-link/serviceBlockReport';
 import { MockDmeLink } from '@/lib/dme-link/mockDmeLink';
 import { WebSerialDmeLink } from '@/lib/dme-link/webSerialDmeLink';
-import { WebSerialTransport } from '@/lib/dme-link/webSerialTransport';
+import { TransportKind, detectTransportKind } from '@/lib/dme-link/byteTransport';
 import { Ds2SupportedBaud, EchoMismatchAnalysis } from '@/lib/dme-link/ds2';
 import { ReadTimingReport } from '@/lib/dme-link/transferTiming';
 
@@ -93,7 +93,22 @@ export function useDmeLink() {
 
     const clearError = useCallback(() => { setError(null); setErrorKind(null); setWarning(null); }, []);
 
-    const isWebSerialSupported = WebSerialTransport.isSupported();
+    /**
+     * Which backend can reach a DME here — `null` until the browser has actually been asked.
+     *
+     * This used to be `WebSerialTransport.isSupported()` evaluated during render, and that was
+     * wrong twice over. On Android it answers *true* while the port picker offers only Bluetooth
+     * SPP, so a K+DCAN cable is unreachable behind a capability check that says it is fine. And
+     * during the static prerender there is no `navigator.serial`, so it answered *false* and baked
+     * "Web Serial API not available in this browser" straight into the exported HTML — every
+     * desktop visitor saw that for a frame before hydration replaced it.
+     *
+     * Resolving after mount fixes both: nothing is asserted about the browser until a browser is
+     * actually present. It also keeps `dialogText()` out of the prerender, which would otherwise
+     * emit Japanese into HTML that an English client then has to reconcile.
+     */
+    const [transportKind, setTransportKind] = useState<TransportKind | null>(null);
+    useEffect(() => { setTransportKind(detectTransportKind()); }, []);
 
     // Progress fires once per DS2 chunk (hundreds of times per read/write). Throttle the React state
     // update to ~10 Hz so the UI doesn't thrash and slow the transfer. 100% and phase changes always
@@ -527,7 +542,7 @@ export function useDmeLink() {
         warningKind,
         transferProgress,
         transferPhase,
-        isWebSerialSupported,
+        transportKind,
         connect,
         disconnect,
         read,

--- a/src/hooks/useHiddenWitness.ts
+++ b/src/hooks/useHiddenWitness.ts
@@ -1,0 +1,39 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+/**
+ * Records whether the page was ever hidden while an operation was running.
+ *
+ * This buys a diagnosis, not a defence. Nothing here can stop Android from freezing a backgrounded
+ * tab mid-write; what it can do is stop the resulting failure from being a mystery. "The write
+ * failed" and "the write failed, and the app was backgrounded while it ran" are the same event and
+ * completely different bug reports — the second one names the cause and the remedy, the first sends
+ * someone looking at the cable.
+ *
+ * That is the same argument the link already makes for `classifyEchoMismatch` and the baud-switch
+ * outcome: when a failure has several plausible causes, record which one actually happened rather
+ * than making the next reader guess.
+ *
+ * A ref, not state: the flag is read at failure time, never rendered, and a setState during a
+ * four-minute transfer is exactly the main-thread work the transport cannot afford. Latched on
+ * `active` going true so each operation is judged on its own.
+ */
+export function useHiddenWitness(active: boolean): () => boolean {
+    const wasHidden = useRef(false);
+
+    useEffect(() => {
+        if (!active) return;
+        wasHidden.current = false;
+        // Catches the case where the operation is started from an already-hidden page — rare, but
+        // it would otherwise report a clean run.
+        if (typeof document !== 'undefined' && document.visibilityState === 'hidden') {
+            wasHidden.current = true;
+        }
+        const onVisibility = () => {
+            if (document.visibilityState === 'hidden') wasHidden.current = true;
+        };
+        document.addEventListener('visibilitychange', onVisibility);
+        return () => document.removeEventListener('visibilitychange', onVisibility);
+    }, [active]);
+
+    return useCallback(() => wasHidden.current, []);
+}

--- a/src/hooks/useScreenWakeLock.ts
+++ b/src/hooks/useScreenWakeLock.ts
@@ -1,0 +1,71 @@
+import { useEffect } from 'react';
+
+/**
+ * Holds the screen awake while a hardware operation is in flight.
+ *
+ * ## Why this exists, and only now
+ *
+ * On desktop it would be close to pointless — the tab keeps running with the monitor asleep. On
+ * Android it is not: the screen switching off is the ordinary path to the tab being frozen and the
+ * USB connection dropped, in the middle of an erase/write/verify that runs for four minutes. That
+ * is the same window `useUnloadGuard` was built for, and this is the half of it that guard cannot
+ * reach.
+ *
+ * ## What it is not
+ *
+ * Not a guarantee, for the same reason the unload guard is not a lock. The browser releases the
+ * sentinel whenever the page is hidden, and the user can always press the power button. What it
+ * removes is the *inactivity* timeout firing halfway through a write — which is the failure that
+ * happens by itself, without anyone deciding anything.
+ *
+ * ## Shape
+ *
+ * Deliberately the same discipline as `useUnloadGuard`: the effect exists exactly while `active` is
+ * true and React's cleanup releases it, so there is no flag to forget to clear and no "release"
+ * step that a failure path can skip. The sentinel lives in a closure variable rather than state
+ * because nothing renders from it, and a setState here would put a render in the middle of a
+ * transfer.
+ *
+ * No watchdog, unlike the unload guard. A leaked wake lock costs battery; a leaked unload guard
+ * traps the tab. And the browser drops it on hide regardless, so it cannot leak for long.
+ *
+ * Re-acquisition on `visibilitychange` is required, not optional: the sentinel is auto-released
+ * every time the page hides, so without this a single glance at a notification would end it for the
+ * rest of the write.
+ */
+export function useScreenWakeLock(active: boolean): void {
+    useEffect(() => {
+        if (!active) return;
+        if (typeof navigator === 'undefined' || !navigator.wakeLock) return;
+
+        let sentinel: WakeLockSentinel | null = null;
+        let released = false;
+
+        const acquire = async () => {
+            if (released || sentinel) return;
+            try {
+                sentinel = await navigator.wakeLock!.request('screen');
+                // The browser may drop it on its own; forget the stale handle so a later
+                // visibilitychange can take a fresh one instead of seeing a non-null sentinel.
+                sentinel.addEventListener('release', () => { sentinel = null; }, { once: true });
+                if (released) { void sentinel.release().catch(() => { }); sentinel = null; }
+            } catch {
+                // Denied, unsupported, or not visible right now. Best-effort by design — the write
+                // must not fail because the screen could not be pinned.
+            }
+        };
+
+        const onVisibility = () => { if (document.visibilityState === 'visible') void acquire(); };
+
+        void acquire();
+        document.addEventListener('visibilitychange', onVisibility);
+
+        return () => {
+            released = true;
+            document.removeEventListener('visibilitychange', onVisibility);
+            const held = sentinel;
+            sentinel = null;
+            if (held) void held.release().catch(() => { });
+        };
+    }, [active]);
+}

--- a/src/hooks/useUnloadGuard.ts
+++ b/src/hooks/useUnloadGuard.ts
@@ -12,6 +12,15 @@ import { useEffect } from 'react';
  * OS shutdown, a crash or a power cut. What it buys is turning an absent-minded Ctrl+R into a choice,
  * during the minutes when that keystroke can leave an ECU half-programmed.
  *
+ * ## Weaker still on Android, and there is nothing to add
+ *
+ * Chrome for Android honours this for a reload and a same-tab navigation, but not dependably for a
+ * tab close, the back gesture, or the OS reclaiming the tab. Do not go looking for a stronger API:
+ * there isn't one. The gap is covered from two other directions instead — `useScreenWakeLock`
+ * removes the commonest way a phone interrupts itself, `useHiddenWitness` records it when something
+ * does, and `dialogText().writeConfirm` states the extra rules plainly on Android before the write
+ * starts. This hook stays exactly as strong as the platform allows and no stronger.
+ *
  * ## Why there is no unlock
  *
  * The obvious shape — a flag set before the operation and cleared after — has a failure mode worse

--- a/src/lib/dialog-text.ts
+++ b/src/lib/dialog-text.ts
@@ -1,5 +1,11 @@
 /**
- * Copy for the browser's native `alert` / `confirm` dialogs, in both display languages.
+ * Copy for the browser's native `alert` / `confirm` dialogs — and for the handful of plain-string
+ * notices rendered outside a React dialog — in both display languages.
+ *
+ * The second case arrived with the notice line on the hub, which had shipped an English-only string
+ * written inline at the call site: exactly the failure the rule below exists to prevent. A plain
+ * string is not JSX, so the component-local TEXT + useDialogLang pattern buys nothing there; it
+ * belongs here.
  *
  * The React dialogs each carry their own TEXT record and pick from it with `useDialogLang`. The
  * native ones had nothing: they were written inline at the call site, so whichever language the
@@ -91,7 +97,7 @@ const JA = {
         '書き込まない場合は、このまま DOWNLOAD TUNED で書き出せます(WRITEが送るバイト列そのもの)。',
 
     // --- flashing the DME ---
-    writeConfirm: (a: { tuned: boolean; patchOn: boolean; drift: string[] }) =>
+    writeConfirm: (a: { tuned: boolean; patchOn: boolean; drift: string[]; android: boolean }) =>
         'DMEへ書き込みます。\n\n' +
         `書き込む内容: ${a.tuned
             ? 'チューニング済みマップ'
@@ -103,9 +109,31 @@ const JA = {
         '  書き込み中は絶対に電源を切ったり、ケーブルを抜いたりしないでください。\n' +
         // ブラウザ側のダイアログは文言を指定できないため、理由を説明できるのはここだけである。
         '  ブラウザのタブを閉じたり、リロードしたりしないでください。\n' +
-        '  (閉じようとすると確認が出ますが、確認を無視すれば離れられてしまいます)\n\n' +
-        'チェックサムは自動補正されます。書き込み後にリードバック検証を行います。\n\n' +
+        '  (閉じようとすると確認が出ますが、確認を無視すれば離れられてしまいます)\n' +
+        // Android では beforeunload の発火が不確実で、上の「確認が出ます」が当てにならない。
+        // 画面消灯・アプリ切替も接続を落としうるため、防げない分をここで明示する。
+        (a.android
+            ? '⚠ この端末(Android)では次の点にも注意してください:\n' +
+            '  画面を消灯させないでください(書き込み中は自動消灯を抑止しますが、手動での消灯は防げません)。\n' +
+            '  他のアプリに切り替えないでください。\n' +
+            '  OTGケーブルとコネクタが動かないよう固定してください。\n'
+            : '') +
+        '\nチェックサムは自動補正されます。書き込み後にリードバック検証を行います。\n\n' +
         '続行しますか？',
+
+    /**
+     * Shown on the notice line when no byte transport can reach a DME here.
+     *
+     * Android and desktop fail for entirely different reasons and need different remedies, so this
+     * takes the platform rather than shipping one vague sentence that fits neither: on Android
+     * `navigator.serial` exists but only enumerates Bluetooth SPP, so the answer is WebUSB + OTG,
+     * not "use Chrome" — the user is already in Chrome.
+     */
+    // 戻り値を string と明示しているのは、リテラル型に推論されると EN 側が JA のリテラル和型に
+    // 代入できなくなるため。EN が JA から型付けされている(NativeDialogText)ことによる制約。
+    noTransport: (a: { android: boolean }): string => a.android
+        ? 'DMEに接続できません — USB OTGアダプタと、WebUSB対応ブラウザ(Chrome)が必要です。PRACTICEならオフラインで試せます。'
+        : 'DMEに接続できません — Chrome/Edgeが必要です(Web Serial API)。PRACTICEならオフラインで試せます。',
 
     patchWriteDone:
         '✅ パッチの書き込みが完了しました(リードバック検証OK)。\n\n' +
@@ -119,9 +147,15 @@ const JA = {
         'OK        = 新規セッションを作成(BASE = 今書き込んだTUNED)\n' +
         'キャンセル = セッション一覧に戻る',
 
-    writeFailed: (reason: string | null) =>
+    writeFailed: (reason: string | null, a?: { wasBackgrounded: boolean }) =>
         '❌ 書き込みに失敗しました。\n\n' +
         `理由: ${reason ?? '不明なエラー'}\n\n` +
+        // 原因を名指しできるならそうする。「ケーブルが悪いのか」を延々調べるのと、
+        // 「バックグラウンドに回ったから」と分かっているのとでは、次にやることが違う。
+        (a?.wasBackgrounded
+            ? '⚠ 書き込み中にこのアプリが画面から外れました(画面消灯またはアプリ切替)。\n' +
+            '  それが原因の可能性が高いです。次回は画面を点けたまま、他のアプリに切り替えずに実行してください。\n\n'
+            : '') +
         '⚠ DMEのデータ領域は消去済みで、書き込みが途中の可能性があります。\n' +
         '  この状態でイグニッションを切ったり走行したりしないでください。\n\n' +
         '対処:\n' +
@@ -195,7 +229,7 @@ const EN: NativeDialogText = {
         'Note: stopping the engine drops the link, so the connection was released here.\n\n' +
         'If you are not writing, you can export it as it is with DOWNLOAD TUNED (the exact bytes WRITE sends).',
 
-    writeConfirm: (a: { tuned: boolean; patchOn: boolean; drift: string[] }) =>
+    writeConfirm: (a: { tuned: boolean; patchOn: boolean; drift: string[]; android: boolean }) =>
         'Writing to the DME.\n\n' +
         `What will be written: ${a.tuned
             ? 'the tuned map'
@@ -206,9 +240,20 @@ const EN: NativeDialogText = {
         '⚠ Keep the power (battery) stable. The write takes about 4 minutes.\n' +
         '  Never cut the power or unplug the cable while it is writing.\n' +
         '  Do not close or reload this browser tab.\n' +
-        '  (Trying to close it asks for confirmation, but confirming still leaves.)\n\n' +
-        'The checksum is corrected automatically. The write is verified by reading it back.\n\n' +
+        '  (Trying to close it asks for confirmation, but confirming still leaves.)\n' +
+        (a.android
+            ? '⚠ On this device (Android), also note:\n' +
+            '  Do not let the screen switch off (auto-off is held back while writing, but a manual\n' +
+            '  press cannot be prevented).\n' +
+            '  Do not switch to another app.\n' +
+            '  Secure the OTG cable and connector so they cannot move.\n'
+            : '') +
+        '\nThe checksum is corrected automatically. The write is verified by reading it back.\n\n' +
         'Continue?',
+
+    noTransport: (a: { android: boolean }) => a.android
+        ? 'Cannot reach a DME — a USB OTG adapter and a WebUSB-capable browser (Chrome) are required. PRACTICE works offline.'
+        : 'Cannot reach a DME — Chrome or Edge is required (Web Serial API). PRACTICE works offline.',
 
     patchWriteDone:
         '✅ The patch write is complete (read-back verified).\n\n' +
@@ -222,9 +267,14 @@ const EN: NativeDialogText = {
         'OK     = create a new session (BASE = the TUNED just written)\n' +
         'Cancel = return to the session list',
 
-    writeFailed: (reason: string | null) =>
+    writeFailed: (reason: string | null, a?: { wasBackgrounded: boolean }) =>
         '❌ The write failed.\n\n' +
         `Reason: ${reason ?? 'unknown error'}\n\n` +
+        (a?.wasBackgrounded
+            ? '⚠ This app left the screen while it was writing (the screen switched off, or you\n' +
+            '  switched apps). That is the most likely cause. Next time, keep the screen on and\n' +
+            '  stay in this app for the whole write.\n\n'
+            : '') +
         "⚠ The DME's data area has already been erased and the write may be incomplete.\n" +
         '  Do not switch the ignition off and do not drive in this state.\n\n' +
         'What to do:\n' +

--- a/src/lib/dme-link/bufferedByteTransport.ts
+++ b/src/lib/dme-link/bufferedByteTransport.ts
@@ -1,0 +1,158 @@
+import { DmeLinkError } from './types';
+import type { TransferTiming } from './transferTiming';
+
+/**
+ * The receive buffer, the parked waiter, and `readExact` — everything a byte transport does *after*
+ * bytes have arrived, independent of how they arrived.
+ *
+ * This was lifted verbatim out of `WebSerialTransport` when the WebUSB backend was added, rather
+ * than copied into it. The waiter semantics below are the most subtle thing in the transport layer
+ * and the throughput investigation in §9 of the implementation notes turned on them; two copies
+ * would drift, and the drift would show up as an intermittent framing fault in a car rather than as
+ * a failing check on a desk. The same reasoning the link applies to its own recovery paths — a
+ * repair must not be allowed to diverge from the thing it repairs — applies here.
+ *
+ * Subclasses own the wire: they call `receive()` as bytes land and `latch()` when the stream faults.
+ */
+export abstract class BufferedByteTransport {
+    protected buffer: number[] = [];
+    protected pumpActive = false;
+    protected pumpError: Error | null = null;
+    /**
+     * A single reader parked in readExact, woken by the pump the moment enough bytes have arrived.
+     *
+     * Replaces a `setTimeout(2)` polling loop. Browsers clamp nested timers to ~4 ms, so that loop
+     * could sit on data that had already arrived for up to a full clamp period — three times per DS2
+     * exchange (echo, header, body). At 9600 the wire dominates and it hides; the faster the rate,
+     * the larger that fixed cost looms, which is why raising the baud stopped producing a speed-up.
+     *
+     * One waiter is enough: the transport is serialised by the link's command gate, so readExact is
+     * never re-entered concurrently.
+     */
+    private waiter: { need: number; wake: () => void } | null = null;
+    /** Optional per-chunk instrument. Null (and every call site optional-chained) so the uninstrumented
+     *  path costs one null check — see transferTiming.ts for why that matters here. */
+    protected timing: TransferTiming | null = null;
+
+    /** Attaches the read-timing instrument. The link owns exchange boundaries; the transport owns byte
+     *  arrival, so both have to write into the same object. */
+    setTiming(timing: TransferTiming | null): void {
+        this.timing = timing;
+    }
+
+    /** Wakes the parked reader once its byte count is satisfiable — or once it can only fail. */
+    private signalWaiter(): void {
+        const w = this.waiter;
+        if (w && (this.buffer.length >= w.need || this.pumpError)) {
+            this.waiter = null;
+            w.wake();
+        }
+    }
+
+    /** Releases a parked reader unconditionally. Used wherever the pump it is waiting on is about to
+     *  be torn down: after that point no byte can ever arrive to wake it, so leaving it parked would
+     *  cost a full timeout for nothing. */
+    protected releaseWaiter(): void {
+        const w = this.waiter;
+        if (w) { this.waiter = null; w.wake(); }
+    }
+
+    /**
+     * Hands received bytes to the buffer and wakes anyone waiting on them.
+     *
+     * Timestamped HERE, not in readExact: readExact only ever learns that enough bytes exist, never
+     * when each arrived. Byte arrival times are the whole point — they are what separates "the DME
+     * was thinking" from "the bytes were here and we were slow to notice".
+     *
+     * Callers must not invoke this for a zero-length arrival: `rxEvents` counts byte deliveries, and
+     * an empty one would inflate it. That matters on the WebUSB backend, where the chip emits a
+     * status packet on every latency-timer expiry whether or not it carries data.
+     */
+    protected receive(bytes: Uint8Array): void {
+        this.timing?.rx(performance.now());
+        for (let i = 0; i < bytes.length; i++) this.buffer.push(bytes[i]);
+        this.signalWaiter();
+    }
+
+    /**
+     * Latches a stream error. A latched error must wake the reader too, or it waits out its whole
+     * timeout for bytes that can no longer arrive — turning a break into a multi-second stall.
+     */
+    protected latch(error: Error): void {
+        this.pumpError = error;
+        this.signalWaiter();
+    }
+
+    protected clearBuffer(): void {
+        this.buffer = [];
+    }
+
+    /** Discards any buffered received bytes — used to resynchronize after a timeout before retrying. */
+    purge(): void {
+        // No waiter can be parked here: purge runs between exchanges, and the link's command gate
+        // makes those strictly sequential. Emptying the buffer under a parked reader would strand it
+        // until its deadline, so if that invariant ever changes this needs a signalWaiter().
+        this.buffer = [];
+    }
+
+    /** How many received bytes are waiting to be consumed. Lets a caller tell whether the line has
+     *  gone quiet (buffer stays empty across a pause) before starting a fresh exchange, rather than
+     *  purging into a stream that is still arriving. */
+    bufferedLength(): number {
+        return this.buffer.length;
+    }
+
+    /** True if the background read pump has latched an error — most often a serial break. Lets a
+     *  caller recover deliberately instead of discovering it as a failed readExact mid-exchange. */
+    hasReadError(): boolean {
+        return this.pumpError !== null;
+    }
+
+    /**
+     * The latched pump error, WITHOUT clearing it, so a caller can name the cause in its own message.
+     *
+     * Deliberately non-consuming: clearing the latch here would make hasReadError() report false, and
+     * resyncTransport() would then purge() instead of recoverRead() — leaving the dead pump unrestarted,
+     * which is strictly worse than not looking at all. Only recoverRead()/open()/reopen() clear it.
+     */
+    peekReadError(): Error | null {
+        return this.pumpError;
+    }
+
+    /**
+     * Reads exactly `length` bytes, waiting up to `timeoutMs`. Surplus bytes received alongside are
+     * retained in the buffer for the next call — never dropped.
+     */
+    async readExact(length: number, timeoutMs: number): Promise<Uint8Array> {
+        const deadline = Date.now() + timeoutMs;
+        while (this.buffer.length < length) {
+            // Name the error class too: a BreakError/FramingError (recoverable, and the signature of a
+            // disturbed K-line) and a NetworkError (device gone) otherwise read identically.
+            if (this.pumpError) {
+                throw new DmeLinkError(`Serial read failed: ${this.pumpError.name} (${this.pumpError.message})`);
+            }
+            const remaining = deadline - Date.now();
+            if (remaining <= 0) {
+                throw new DmeLinkError(`Timed out waiting for ${length} byte(s) (received ${this.buffer.length})`);
+            }
+            // Park until the pump says the bytes are here, or the deadline passes — whichever first.
+            // The loop still re-checks afterwards, so a spurious wake costs one comparison.
+            //
+            // Parked time is measured because it is the honest accounting of "waiting for the wire"
+            // versus "us being slow": if parked time is close to the total, the bytes genuinely were
+            // not here yet and no host-side change helps.
+            this.timing?.parkStart(performance.now());
+            await new Promise<void>(resolve => {
+                let timer: ReturnType<typeof setTimeout> | undefined;
+                const wake = () => { if (timer !== undefined) clearTimeout(timer); resolve(); };
+                timer = setTimeout(() => {
+                    if (this.waiter?.wake === wake) this.waiter = null;
+                    resolve();
+                }, remaining);
+                this.waiter = { need: length, wake };
+            });
+            this.timing?.parkEnd(performance.now());
+        }
+        return Uint8Array.from(this.buffer.splice(0, length));
+    }
+}

--- a/src/lib/dme-link/byteTransport.ts
+++ b/src/lib/dme-link/byteTransport.ts
@@ -1,0 +1,100 @@
+import { DmeLinkError } from './types';
+import type { TransferTiming } from './transferTiming';
+import { WebSerialTransport } from './webSerialTransport';
+import { WebUsbFtdiTransport } from './webUsbFtdiTransport';
+
+/**
+ * The contract `webSerialTransport.ts` has always claimed to implement and never declared.
+ *
+ * Its header comment said it "mirrors the reference app's IByteTransport contract" while no such
+ * TypeScript interface existed, so there was nothing stopping a second backend from drifting. There
+ * is a second backend now — WebUSB, for Android — so the contract becomes real.
+ *
+ * Every member here is one the DS2 layer already calls. This is deliberately a description of the
+ * existing surface, not a redesign of it: `WebSerialDmeLink` makes 21 transport calls and not one of
+ * them changes.
+ */
+export interface ByteTransport {
+    setTiming(timing: TransferTiming | null): void;
+    open(): Promise<void>;
+    close(): Promise<void>;
+    reopen(baudRate: number): Promise<void>;
+    write(bytes: Uint8Array): Promise<void>;
+    /**
+     * Synchronous by contract, and it must stay that way. `resyncTransport` calls it without
+     * awaiting and `drainUntilQuiet` reads `bufferedLength()` straight afterwards expecting zero
+     * (webSerialDmeLink.ts:1199-1230). Returning a promise here would silently change the shape of
+     * code that was tuned against a real car.
+     */
+    purge(): void;
+    bufferedLength(): number;
+    hasReadError(): boolean;
+    peekReadError(): Error | null;
+    recoverRead(): Promise<void>;
+    readExact(length: number, timeoutMs: number): Promise<Uint8Array>;
+}
+
+/**
+ * Which backend can reach a DME here.
+ *
+ * 'none' is a real answer, not an error: the file-upload workflow stays fully usable without any
+ * hardware transport, so this only gates the direct-DME features.
+ */
+export type TransportKind = 'web-serial' | 'web-usb-ftdi' | 'none';
+
+/**
+ * True on Android, which is the one platform where capability detection cannot decide for us.
+ *
+ * `userAgentData.platform` is Chromium's own structured answer and is not subject to the UA-string
+ * freezing games; the regex is the fallback for engines that do not expose it.
+ */
+export function isAndroidPlatform(): boolean {
+    if (typeof navigator === 'undefined') return false;
+    const uaData = (navigator as Navigator & { userAgentData?: { platform?: string } }).userAgentData;
+    if (uaData?.platform) return uaData.platform === 'Android';
+    return /android/i.test(navigator.userAgent);
+}
+
+/**
+ * Picks the backend for this browser.
+ *
+ * **This is the one place in the app that looks at the platform rather than at a capability, and it
+ * has to.** Chrome for Android 138+ exposes `navigator.serial`, so `'serial' in navigator` is true
+ * there — but it enumerates *only* Bluetooth RFCOMM serial-port emulation, and a USB K+DCAN cable
+ * never appears in its picker. There is no feature test that separates "Web Serial that can see USB
+ * adapters" from "Web Serial that can see only Bluetooth SPP": both objects are identical, and the
+ * difference shows up as an empty chooser after the user has already tapped through a permission
+ * prompt. So Android is asked by name and routed to WebUSB.
+ *
+ * `?transport=webusb` / `?transport=webserial` overrides the choice. It costs nothing on a static
+ * export, and it is what lets the WebUSB path be driven from a desktop bench rig — which matters a
+ * great deal when the alternative is testing a new byte transport for the first time in a car.
+ */
+export function detectTransportKind(): TransportKind {
+    // Static prerender: neither API can exist, and answering 'none' here would bake an
+    // "unsupported browser" notice into the exported HTML. Callers must resolve this after mount.
+    if (typeof navigator === 'undefined' || typeof location === 'undefined') return 'none';
+
+    const forced = new URLSearchParams(location.search).get('transport');
+    if (forced === 'webusb') return WebUsbFtdiTransport.isSupported() ? 'web-usb-ftdi' : 'none';
+    if (forced === 'webserial') return WebSerialTransport.isSupported() ? 'web-serial' : 'none';
+
+    if (isAndroidPlatform()) return WebUsbFtdiTransport.isSupported() ? 'web-usb-ftdi' : 'none';
+    return WebSerialTransport.isSupported() ? 'web-serial' : 'none';
+}
+
+/**
+ * Builds the transport this browser can actually use.
+ *
+ * Detection happens here rather than being passed in, so the decision is made at connect time — a
+ * phone that gains an OTG adapter between page load and the first tap does not need a reload.
+ */
+export function createDmeTransport(): ByteTransport {
+    switch (detectTransportKind()) {
+        case 'web-serial': return new WebSerialTransport();
+        case 'web-usb-ftdi': return new WebUsbFtdiTransport();
+        default: throw new DmeLinkError(
+            'No serial transport is available in this browser. Chrome or Edge is required on desktop; ' +
+            'on Android, Chrome with a USB OTG adapter.');
+    }
+}

--- a/src/lib/dme-link/webSerialDmeLink.ts
+++ b/src/lib/dme-link/webSerialDmeLink.ts
@@ -1,6 +1,6 @@
 import { DmeLink, DmeIdentity, LiveMeasurement, TransferProgress, DmeLinkError, ServiceBlockErasedCause, ServiceBlockDump } from './types';
 import { ServiceBlockPointers } from './serviceBlockReport';
-import { WebSerialTransport } from './webSerialTransport';
+import { ByteTransport, createDmeTransport } from './byteTransport';
 import {
     Ds2Frame, Ds2Control, Ds2ProgrammingControl, Ds2BaudRate, Ds2BaudRateSpec, Ds2SupportedBaud, ds2BaudSpecFor,
     Mss54HpDataTuneLayout, DS2_DEFAULT_ADDRESS,
@@ -143,9 +143,15 @@ function assertWriteChunkingLegal(blocks: readonly { address: number; length: nu
 }
 
 /**
- * Real DME connection over a K+DCAN-style cable via the Web Serial API, using the BMW DS2
- * protocol. Requires Chrome/Edge desktop and must be initiated from a genuine user gesture
- * (the browser's serial port picker cannot be triggered programmatically).
+ * Real DME connection over a K+DCAN-style cable, using the BMW DS2 protocol.
+ *
+ * The name is now slightly narrower than the truth: the byte transport underneath is Web Serial on
+ * desktop and the FTDI vendor protocol over WebUSB on Android (see byteTransport.ts). Nothing in
+ * this file knows which — it holds a `ByteTransport` and every one of its calls is the same on both.
+ * The class keeps its name deliberately; renaming a 1400-line file with dense blame buys nothing.
+ *
+ * Must be initiated from a genuine user gesture on either backend: neither the serial port picker
+ * nor the USB device chooser can be triggered programmatically.
  *
  * Read/write addressing for the MSS54HP "DataTune" partial BIN, identity (VIN/AIF/software
  * version) parsing, and the live-measurement block layout are all confirmed against the
@@ -154,7 +160,7 @@ function assertWriteChunkingLegal(blocks: readonly { address: number; length: nu
  * genuine user click that cannot be automated.
  */
 export class WebSerialDmeLink implements DmeLink {
-    private transport = new WebSerialTransport();
+    private readonly transport: ByteTransport;
     private connected = false;
     private aborted = false;
     /**
@@ -221,8 +227,15 @@ export class WebSerialDmeLink implements DmeLink {
         this.transport.setTiming(enabled ? this.timing : null);
     }
 
-    constructor(options?: { readBaud?: Ds2SupportedBaud }) {
+    /**
+     * `transport` exists for the bench harness and for a future byte-level fake; production passes
+     * nothing and gets whatever this browser can reach — Web Serial on desktop, the FTDI vendor
+     * protocol over WebUSB on Android. Deciding it in the factory rather than at the call site keeps
+     * the React layer free of platform knowledge.
+     */
+    constructor(options?: { readBaud?: Ds2SupportedBaud; transport?: ByteTransport }) {
         this.readBaud = options?.readBaud ?? 9600;
+        this.transport = options?.transport ?? createDmeTransport();
     }
 
     abort(): void {

--- a/src/lib/dme-link/webSerialTransport.ts
+++ b/src/lib/dme-link/webSerialTransport.ts
@@ -1,16 +1,17 @@
 import { DmeLinkError } from './types';
-import type { TransferTiming } from './transferTiming';
+import { BufferedByteTransport } from './bufferedByteTransport';
+import type { ByteTransport } from './byteTransport';
 
 /**
- * Thin wrapper isolating all navigator.serial calls, mirroring the reference app's IByteTransport
- * contract (open/write/read/close over a single serial port).
+ * Thin wrapper isolating all navigator.serial calls — the desktop backend, and the one proven on a
+ * real vehicle.
  *
- * Received bytes are drained by a single background pump into an internal buffer, and readExact()
- * consumes from that buffer. This is deliberate: the Web Serial reader delivers bytes in arbitrary
- * chunk boundaries, so a DS2 echo and the start of its response frequently arrive in the *same*
- * chunk. A naive "read one chunk per readExact" approach drops the surplus and desynchronizes the
- * stream — which is exactly what broke bulk (269-chunk) partial-BIN reads. Buffering never drops a
- * byte, keeping echo/response framing aligned across thousands of exchanges.
+ * The buffering half (the receive buffer, the parked waiter, readExact) lives in
+ * BufferedByteTransport, shared with the WebUSB backend. What stays here is everything that touches
+ * a SerialPort. The reason the buffering exists at all is unchanged: the Web Serial reader delivers
+ * bytes in arbitrary chunk boundaries, so a DS2 echo and the start of its response frequently arrive
+ * in the *same* chunk. A naive "read one chunk per readExact" approach drops the surplus and
+ * desynchronizes the stream — which is exactly what broke bulk (269-chunk) partial-BIN reads.
  */
 /**
  * Receive buffer requested from the Web Serial implementation. We were passing no bufferSize at all,
@@ -32,55 +33,25 @@ import type { TransferTiming } from './transferTiming';
  * which comes back as an echo mismatch — and classifyEchoMismatch would most likely score that
  * 'unclassified'. That makes it a live candidate for the intermittent echo faults in the notes, and
  * the transfer timer's `write` median is the measurement that tests it: it should be ~0.
+ *
+ * Note that the WebUSB backend has no equivalent: there, nothing drains the chip's FIFO except our
+ * own read loop, on the renderer thread. See webUsbFtdiTransport.ts.
  */
 const RX_BUFFER_BYTES = 4096;
 
-export class WebSerialTransport {
+export class WebSerialTransport extends BufferedByteTransport implements ByteTransport {
     private port: SerialPort | null = null;
     private reader: ReadableStreamDefaultReader<Uint8Array> | null = null;
     private writer: WritableStreamDefaultWriter<Uint8Array> | null = null;
-    private buffer: number[] = [];
-    private pumpActive = false;
-    private pumpError: Error | null = null;
+
     /**
-     * A single reader parked in readExact, woken by the pump the moment enough bytes have arrived.
+     * Whether this browser exposes Web Serial at all.
      *
-     * Replaces a `setTimeout(2)` polling loop. Browsers clamp nested timers to ~4 ms, so that loop
-     * could sit on data that had already arrived for up to a full clamp period — three times per DS2
-     * exchange (echo, header, body). At 9600 the wire dominates and it hides; the faster the rate,
-     * the larger that fixed cost looms, which is why raising the baud stopped producing a speed-up.
-     *
-     * One waiter is enough: the transport is serialised by the link's command gate, so readExact is
-     * never re-entered concurrently.
+     * Note what this deliberately does NOT answer: whether the ports it enumerates include USB
+     * serial adapters. Chrome for Android 138+ returns true here and then offers only Bluetooth
+     * RFCOMM ports, so a K+DCAN cable is unreachable despite this being true. That distinction is
+     * made in byteTransport.ts, which is the only caller that needs it.
      */
-    private waiter: { need: number; wake: () => void } | null = null;
-    /** Optional per-chunk instrument. Null (and every call site optional-chained) so the uninstrumented
-     *  path costs one null check — see transferTiming.ts for why that matters here. */
-    private timing: TransferTiming | null = null;
-
-    /** Attaches the read-timing instrument. The link owns exchange boundaries; the transport owns byte
-     *  arrival, so both have to write into the same object. */
-    setTiming(timing: TransferTiming | null): void {
-        this.timing = timing;
-    }
-
-    /** Wakes the parked reader once its byte count is satisfiable — or once it can only fail. */
-    private signalWaiter(): void {
-        const w = this.waiter;
-        if (w && (this.buffer.length >= w.need || this.pumpError)) {
-            this.waiter = null;
-            w.wake();
-        }
-    }
-
-    /** Releases a parked reader unconditionally. Used wherever the pump it is waiting on is about to
-     *  be torn down: after that point no byte can ever arrive to wake it, so leaving it parked would
-     *  cost a full timeout for nothing. */
-    private releaseWaiter(): void {
-        const w = this.waiter;
-        if (w) { this.waiter = null; w.wake(); }
-    }
-
     static isSupported(): boolean {
         return typeof navigator !== 'undefined' && 'serial' in navigator;
     }
@@ -99,7 +70,7 @@ export class WebSerialTransport {
         await this.deassertControlLines();
         this.writer = this.port.writable!.getWriter();
         this.reader = this.port.readable!.getReader();
-        this.buffer = [];
+        this.clearBuffer();
         this.pumpError = null;
         this.pumpActive = true;
         this.startPump();
@@ -117,6 +88,9 @@ export class WebSerialTransport {
      * and on some K+DCAN cables they gate the K-line transceiver. Making the state explicit and
      * identical on both sides of the reopen removes that variable.
      *
+     * (The WebUSB backend does not inherit this problem: it changes baud in place, so the lines are
+     * set once at open and never disturbed again.)
+     *
      * Best-effort: a cable that does not implement the request must not fail the connection.
      */
     private async deassertControlLines(): Promise<void> {
@@ -132,21 +106,10 @@ export class WebSerialTransport {
                 while (this.pumpActive) {
                     const { value, done } = await reader.read();
                     if (done) break;
-                    if (value) {
-                        // Timestamped HERE, not in readExact: readExact only ever learns that enough
-                        // bytes exist, never when each arrived. Byte arrival times are the whole point
-                        // — they are what separates "the DME was thinking" from "the bytes were here
-                        // and we were slow to notice".
-                        this.timing?.rx(performance.now());
-                        for (let i = 0; i < value.length; i++) this.buffer.push(value[i]);
-                        this.signalWaiter();
-                    }
+                    if (value && value.length > 0) this.receive(value);
                 }
             } catch (e: unknown) {
-                this.pumpError = e instanceof Error ? e : new Error(String(e));
-                // A latched error must wake the reader too, or it waits out its whole timeout for
-                // bytes that can no longer arrive — turning a break into a multi-second stall.
-                this.signalWaiter();
+                this.latch(e instanceof Error ? e : new Error(String(e)));
             }
         })();
     }
@@ -161,7 +124,7 @@ export class WebSerialTransport {
         this.reader = null;
         this.writer = null;
         this.port = null;
-        this.buffer = [];
+        this.clearBuffer();
     }
 
     /**
@@ -183,7 +146,7 @@ export class WebSerialTransport {
         await this.deassertControlLines();
         this.writer = port.writable!.getWriter();
         this.reader = port.readable!.getReader();
-        this.buffer = [];
+        this.clearBuffer();
         this.pumpError = null;
         this.pumpActive = true;
         this.startPump();
@@ -198,38 +161,6 @@ export class WebSerialTransport {
         this.timing?.writeStart(performance.now());
         await this.writer.write(bytes);
         this.timing?.writeEnd(performance.now());
-    }
-
-    /** Discards any buffered received bytes — used to resynchronize after a timeout before retrying. */
-    purge(): void {
-        // No waiter can be parked here: purge runs between exchanges, and the link's command gate
-        // makes those strictly sequential. Emptying the buffer under a parked reader would strand it
-        // until its deadline, so if that invariant ever changes this needs a signalWaiter().
-        this.buffer = [];
-    }
-
-    /** How many received bytes are waiting to be consumed. Lets a caller tell whether the line has
-     *  gone quiet (buffer stays empty across a pause) before starting a fresh exchange, rather than
-     *  purging into a stream that is still arriving. */
-    bufferedLength(): number {
-        return this.buffer.length;
-    }
-
-    /** True if the background read pump has latched an error — most often a serial break. Lets a
-     *  caller recover deliberately instead of discovering it as a failed readExact mid-exchange. */
-    hasReadError(): boolean {
-        return this.pumpError !== null;
-    }
-
-    /**
-     * The latched pump error, WITHOUT clearing it, so a caller can name the cause in its own message.
-     *
-     * Deliberately non-consuming: clearing the latch here would make hasReadError() report false, and
-     * resyncTransport() would then purge() instead of recoverRead() — leaving the dead pump unrestarted,
-     * which is strictly worse than not looking at all. Only recoverRead()/open()/reopen() clear it.
-     */
-    peekReadError(): Error | null {
-        return this.pumpError;
     }
 
     /**
@@ -255,46 +186,9 @@ export class WebSerialTransport {
             throw new DmeLinkError('The serial device disconnected — unplug and replug the cable, then reconnect.');
         }
         this.reader = this.port.readable.getReader();
-        this.buffer = [];
+        this.clearBuffer();
         this.pumpError = null;
         this.pumpActive = true;
         this.startPump();
-    }
-
-    /**
-     * Reads exactly `length` bytes, waiting up to `timeoutMs`. Surplus bytes received alongside are
-     * retained in the buffer for the next call — never dropped.
-     */
-    async readExact(length: number, timeoutMs: number): Promise<Uint8Array> {
-        const deadline = Date.now() + timeoutMs;
-        while (this.buffer.length < length) {
-            // Name the error class too: a BreakError/FramingError (recoverable, and the signature of a
-            // disturbed K-line) and a NetworkError (device gone) otherwise read identically.
-            if (this.pumpError) {
-                throw new DmeLinkError(`Serial read failed: ${this.pumpError.name} (${this.pumpError.message})`);
-            }
-            const remaining = deadline - Date.now();
-            if (remaining <= 0) {
-                throw new DmeLinkError(`Timed out waiting for ${length} byte(s) (received ${this.buffer.length})`);
-            }
-            // Park until the pump says the bytes are here, or the deadline passes — whichever first.
-            // The loop still re-checks afterwards, so a spurious wake costs one comparison.
-            //
-            // Parked time is measured because it is the honest accounting of "waiting for the wire"
-            // versus "us being slow": if parked time is close to the total, the bytes genuinely were
-            // not here yet and no host-side change helps.
-            this.timing?.parkStart(performance.now());
-            await new Promise<void>(resolve => {
-                let timer: ReturnType<typeof setTimeout> | undefined;
-                const wake = () => { if (timer !== undefined) clearTimeout(timer); resolve(); };
-                timer = setTimeout(() => {
-                    if (this.waiter?.wake === wake) this.waiter = null;
-                    resolve();
-                }, remaining);
-                this.waiter = { need: length, wake };
-            });
-            this.timing?.parkEnd(performance.now());
-        }
-        return Uint8Array.from(this.buffer.splice(0, length));
     }
 }

--- a/src/lib/dme-link/webUsb.d.ts
+++ b/src/lib/dme-link/webUsb.d.ts
@@ -1,0 +1,120 @@
+// Minimal ambient types for the WebUSB API (not part of TypeScript's default DOM lib).
+// Covers only what this app uses — same approach as webSerial.d.ts, and for the same reason: a
+// types package would be a dependency carrying far more surface than the handful of calls the FTDI
+// transport makes.
+
+interface USBEndpoint {
+    readonly endpointNumber: number;
+    readonly direction: 'in' | 'out';
+    readonly type: 'bulk' | 'interrupt' | 'isochronous';
+    readonly packetSize: number;
+}
+
+interface USBAlternateInterface {
+    readonly alternateSetting: number;
+    readonly interfaceClass: number;
+    readonly endpoints: USBEndpoint[];
+}
+
+interface USBInterface {
+    readonly interfaceNumber: number;
+    readonly alternate: USBAlternateInterface;
+    readonly alternates: USBAlternateInterface[];
+    readonly claimed: boolean;
+}
+
+interface USBConfiguration {
+    readonly configurationValue: number;
+    readonly interfaces: USBInterface[];
+}
+
+interface USBControlTransferParameters {
+    requestType: 'standard' | 'class' | 'vendor';
+    recipient: 'device' | 'interface' | 'endpoint' | 'other';
+    request: number;
+    value: number;
+    index: number;
+}
+
+type USBTransferStatus = 'ok' | 'stall' | 'babble';
+
+interface USBInTransferResult {
+    readonly data?: DataView;
+    readonly status?: USBTransferStatus;
+}
+
+interface USBOutTransferResult {
+    readonly bytesWritten: number;
+    readonly status?: USBTransferStatus;
+}
+
+interface USBDevice {
+    readonly vendorId: number;
+    readonly productId: number;
+    /** bcdDevice high byte — libftdi's own way of telling FT232R (6) from FT232BM (4), 232H (9), etc. */
+    readonly deviceVersionMajor: number;
+    readonly deviceVersionMinor: number;
+    readonly manufacturerName?: string;
+    readonly productName?: string;
+    readonly serialNumber?: string;
+    readonly opened: boolean;
+    readonly configuration: USBConfiguration | null;
+    readonly configurations: USBConfiguration[];
+    open(): Promise<void>;
+    close(): Promise<void>;
+    selectConfiguration(configurationValue: number): Promise<void>;
+    claimInterface(interfaceNumber: number): Promise<void>;
+    releaseInterface(interfaceNumber: number): Promise<void>;
+    controlTransferIn(setup: USBControlTransferParameters, length: number): Promise<USBInTransferResult>;
+    // ArrayBufferView rather than BufferSource: TypeScript 5.7 made typed arrays generic over their
+    // backing buffer, so a plain Uint8Array is Uint8Array<ArrayBufferLike> and no longer assignable
+    // to BufferSource. The spec accepts any view; this says so without forcing casts at call sites.
+    controlTransferOut(setup: USBControlTransferParameters, data?: ArrayBufferView | ArrayBuffer): Promise<USBOutTransferResult>;
+    transferIn(endpointNumber: number, length: number): Promise<USBInTransferResult>;
+    transferOut(endpointNumber: number, data: ArrayBufferView | ArrayBuffer): Promise<USBOutTransferResult>;
+    clearHalt(direction: 'in' | 'out', endpointNumber: number): Promise<void>;
+    reset(): Promise<void>;
+}
+
+interface USBConnectionEvent extends Event {
+    readonly device: USBDevice;
+}
+
+interface USBDeviceFilter {
+    vendorId?: number;
+    productId?: number;
+    classCode?: number;
+}
+
+interface USB extends EventTarget {
+    getDevices(): Promise<USBDevice[]>;
+    requestDevice(options: { filters: USBDeviceFilter[] }): Promise<USBDevice>;
+    addEventListener(
+        type: 'connect' | 'disconnect',
+        listener: (event: USBConnectionEvent) => void,
+        options?: boolean | AddEventListenerOptions,
+    ): void;
+    removeEventListener(
+        type: 'connect' | 'disconnect',
+        listener: (event: USBConnectionEvent) => void,
+        options?: boolean | EventListenerOptions,
+    ): void;
+}
+
+interface Navigator {
+    usb?: USB;
+}
+
+interface WakeLockSentinel extends EventTarget {
+    readonly released: boolean;
+    readonly type: 'screen';
+    release(): Promise<void>;
+}
+
+interface WakeLock {
+    request(type: 'screen'): Promise<WakeLockSentinel>;
+}
+
+interface Navigator {
+    wakeLock?: WakeLock;
+}

--- a/src/lib/dme-link/webUsbFtdiTransport.ts
+++ b/src/lib/dme-link/webUsbFtdiTransport.ts
@@ -1,0 +1,462 @@
+import { DmeLinkError } from './types';
+import { BufferedByteTransport } from './bufferedByteTransport';
+import type { ByteTransport } from './byteTransport';
+
+/**
+ * The FTDI vendor protocol over WebUSB — the Android backend.
+ *
+ * ## Why this exists at all
+ *
+ * §"Out of scope" in the implementation notes rejected WebUSB, and that rejection is still correct
+ * *for Windows*: Chromium claims USB devices there through WinUSB, an FTDI cable is bound to
+ * `ftdibus.sys`, and rebinding it with Zadig removes the COM port and breaks INPA / Tool32 / ISTA.
+ * None of that exists on Android — there is no VCP driver to displace and no other BMW tool sharing
+ * the cable. And it is not merely permitted there, it is the only option: Chrome for Android 138+
+ * exposes `navigator.serial`, but it enumerates only Bluetooth RFCOMM serial-port emulation, so a
+ * USB K+DCAN cable never appears in its picker.
+ *
+ * Desktop keeps Web Serial. This file is not an attempt to replace a path proven on a car.
+ *
+ * ## What is genuinely different here, and it is not throughput
+ *
+ * With Web Serial the *browser process* drains the endpoint into a 4096-byte mojo pipe on our
+ * behalf. With WebUSB the only thing draining the FT232R's 256-byte RX FIFO is the read loop below,
+ * running on the same thread as React. At 9600 that FIFO is ~267 ms of headroom, so a long
+ * main-thread stall can overrun the chip. The saving grace is that this is *detected* rather than
+ * silent: it arrives as the OE bit in a status header and latches a BufferOverrunError, which the
+ * link's existing retry machinery already handles.
+ *
+ * This is also the whole reason the latency timer is left at the chip default of 16 ms. See
+ * FTDI_LATENCY_MS.
+ */
+
+/** FTDI's USB vendor ID. The chooser filter — a CH340 cable can never reach this code. */
+const FTDI_VENDOR_ID = 0x0403;
+
+const SIO_RESET = 0x00;
+const SIO_SET_MODEM_CTRL = 0x01;
+const SIO_SET_FLOW_CTRL = 0x02;
+const SIO_SET_BAUD_RATE = 0x03;
+const SIO_SET_DATA = 0x04;
+const SIO_SET_LATENCY_TIMER = 0x09;
+
+/** `SIO_RESET` sub-commands. */
+const SIO_RESET_SIO = 0;
+/**
+ * Flush the *receive* buffer.
+ *
+ * The polarity here is a known trap. libftdi ≤1.4 exposed `SIO_RESET_PURGE_RX = 1`, but libftdi 1.5
+ * deprecated those functions and shipped `ftdi_tciflush()` — the *input* flush — using value 2,
+ * because the old naming had RX and TX swapped. 2 is the corrected value. The bench loopback check
+ * in /usb-check exercises exactly this: queue bytes, flush, confirm they are gone.
+ */
+const SIO_RESET_PURGE_RX = 2;
+
+/** Port A. libftdi passes 1 here for single-channel parts; ftdi_sio passes 0. The firmware accepts
+ *  both — this is stated so nobody "fixes" it in one direction and creates a difference to chase. */
+const FTDI_PORT_INDEX = 1;
+
+/**
+ * 8 data bits, even parity, 1 stop bit.
+ *
+ * bits 0-7 data bits (8), bits 8-10 parity (0=N 1=O 2=E), bits 11-13 stop (0=1), bit 14 TX break.
+ * So 8 | (2 << 8) = 0x0208.
+ *
+ * **8E1 is mandatory — do not "simplify" this to 8N1 while chasing line errors.** DS2/MSS54 is
+ * even-parity; an 8N1 receiver samples the parity bit where the stop bit should be, so every
+ * even-popcount byte raises a framing error. DS2's own address 0x12 and ACK 0xA0 both have popcount
+ * 2, so effectively every frame would fault on its first byte. Same constraint, same reasoning, as
+ * the Web Serial backend's `parity: 'even'`.
+ */
+const FTDI_DATA_8E1 = 0x0208;
+/** 8E1 plus bit 14 — holds the line in a break condition. Used only by the /usb-check self-test. */
+export const FTDI_DATA_8E1_TX_BREAK = FTDI_DATA_8E1 | 0x4000;
+
+/**
+ * DTR and RTS both de-asserted, in one request.
+ *
+ * State is bit 0 (DTR) / bit 1 (RTS); the mask enabling each is bit 8 / bit 9. Setting mask bits
+ * with clear state bits gives 0x0300. This is the exact equivalent of the Web Serial backend's
+ * `setSignals({ dataTerminalReady: false, requestToSend: false })`, and it has to be exactly right:
+ * on some K+DCAN cables these lines gate the K-line transceiver, so an inverted polarity is a cable
+ * that connects on desktop and stays silent on the phone.
+ */
+const FTDI_MODEM_DTR_LOW_RTS_LOW = 0x0300;
+
+/**
+ * Latency timer, in milliseconds. **16 — the chip default — and deliberately not lower.**
+ *
+ * The implementation notes predicted 2-4 ms as a sweet spot, but that analysis was about *tail
+ * latency under Web Serial*, where the browser process absorbs the wakeups. It does not transfer to
+ * this backend. Two facts decide it here:
+ *
+ * 1. The timer was already swept on the car and ruled out by measurement: 135 → 14 wakeups per
+ *    chunk changed nothing, and 16 ms was 5.7% *slower*. It is not a throughput lever.
+ * 2. The chip emits a 2-byte status packet on *every* expiry whether or not it has data, and on
+ *    this backend every one of those is a `transferIn` resolution on the React main thread. 16 ms
+ *    is 62.5 idle wakeups/s; 1 ms would be 1000/s. That is precisely the regression the Linux
+ *    kernel reverted in ftdi_sio after eight years, and FTDI's own AN_107 says 1 ms is not
+ *    recommended because it equals the USB frame length.
+ *
+ * 8 is the only other value worth trying. Never 1.
+ */
+const FTDI_LATENCY_MS = 16;
+
+/** Line-status (16550 LSR) bits in byte 1 of every packet header. */
+const LSR_OVERRUN = 0x02;
+const LSR_PARITY = 0x04;
+const LSR_FRAMING = 0x08;
+const LSR_BREAK = 0x10;
+const LSR_ANY_ERROR = LSR_OVERRUN | LSR_PARITY | LSR_FRAMING | LSR_BREAK;
+
+/** Chip families whose baud divisors follow the 3 MHz / fractional encoding below. AM=2, BM=4, R=6.
+ *  The H parts (2232H/4232H/232H) and FT-X use a 12 MHz base and a different index packing, so they
+ *  are refused rather than silently mis-clocked at a device that flashes an ECU. */
+const SUPPORTED_CHIP_VERSIONS = new Set([2, 4, 6]);
+
+/**
+ * Baud divisors, precomputed and audited.
+ *
+ * The encoding: the divisor is carried as an integer plus a 3-bit fractional code, against a 3 MHz
+ * base clock. Working in eighths (24 MHz = 3 MHz x 8):
+ *
+ *     d8       = 24_000_000 / baud
+ *     fracCode = [0,3,2,4,1,5,6,7][d8 & 7]
+ *     encoded  = (d8 >> 3) | (fracCode << 14)
+ *     value    = encoded & 0xFFFF,  index = encoded >>> 16
+ *
+ * A three-entry table rather than the general converter, because `DS2_SELECTABLE_BAUDS` is exactly
+ * these three and ds2.ts documents at length why it will not grow. Three audited constants cannot
+ * be subtly wrong; a general converter can. 0x4138 and 0xC04E match FTDI's published AN232B-05
+ * table, which is the independent check that the derivation above is right. All three rates are
+ * exact — zero baud error, including 125000.
+ */
+const FTDI_DIVISORS: Readonly<Record<number, { value: number; index: number }>> = {
+    9600: { value: 0x4138, index: 0 },   // d8=2500 -> int 312, frac 4/8 -> code 1
+    38400: { value: 0xC04E, index: 0 },  // d8=625  -> int 78,  frac 1/8 -> code 3
+    125000: { value: 0x0018, index: 0 }, // d8=192  -> int 24,  frac 0
+};
+
+/**
+ * Recomputes the table at module load.
+ *
+ * There is no test runner in this project, so a module-load assertion is the only mechanism that
+ * can fail a wrong constant in every environment including production. ds2.ts already establishes
+ * the convention. A wrong divisor is not a subtle bug here — it is a garbled write to an ECU.
+ */
+(function assertDivisorTable(): void {
+    const FRAC_CODE = [0, 3, 2, 4, 1, 5, 6, 7];
+    for (const [baudText, expected] of Object.entries(FTDI_DIVISORS)) {
+        const baud = Number(baudText);
+        const d8 = 24_000_000 / baud;
+        if (!Number.isInteger(d8)) throw new Error(`FTDI divisor table: ${baud} is not an exact 1/8 divisor`);
+        const encoded = (d8 >> 3) | (FRAC_CODE[d8 & 7] << 14);
+        const value = encoded & 0xFFFF;
+        const index = encoded >>> 16;
+        if (value !== expected.value || index !== expected.index) {
+            throw new Error(
+                `FTDI divisor table wrong for ${baud}: table says ` +
+                `0x${expected.value.toString(16)}/${expected.index}, computed ` +
+                `0x${value.toString(16)}/${index}`);
+        }
+    }
+    if (FTDI_DATA_8E1 !== 0x0208) throw new Error('FTDI 8E1 constant is wrong');
+    if (FTDI_MODEM_DTR_LOW_RTS_LOW !== 0x0300) throw new Error('FTDI modem-control constant is wrong');
+})();
+
+/** A line fault reported through a status header. The NAME is what matters: readExact prints it and
+ *  §9's triage table is written against the Web Serial spelling of these, so they must match. */
+class FtdiLineError extends Error {
+    constructor(name: string, message: string) {
+        super(message);
+        this.name = name;
+    }
+}
+
+export class WebUsbFtdiTransport extends BufferedByteTransport implements ByteTransport {
+    private device: USBDevice | null = null;
+    private interfaceNumber = 0;
+    private inEndpoint = 0;
+    private outEndpoint = 0;
+    private packetSize = 64;
+    /** Set by the navigator.usb 'disconnect' listener. The WebUSB analogue of Chromium leaving
+     *  port.readable null, and more reliable than probing device.opened. */
+    private deviceGone = false;
+    /** Resolves when the read loop has actually exited, so recoverRead does not race it. */
+    private pumpExited: Promise<void> = Promise.resolve();
+    /**
+     * LSR bits are latched-since-last-read, so the first packet after a (re)start can report a
+     * condition that predates us — most visibly the break we just recovered from. Ignoring line
+     * status on exactly one packet stops recovery from immediately re-latching the fault it repaired.
+     */
+    private skipLineStatusOnce = false;
+
+    static isSupported(): boolean {
+        return typeof navigator !== 'undefined' && 'usb' in navigator && navigator.usb !== undefined;
+    }
+
+    private onDisconnect = (event: USBConnectionEvent): void => {
+        if (this.device && event.device === this.device) {
+            this.deviceGone = true;
+            this.latch(new FtdiLineError('NetworkError', 'The device was disconnected'));
+        }
+    };
+
+    /** One vendor OUT request. bmRequestType 0x40 is what `requestType: 'vendor'` + device recipient
+     *  encodes, which is what the FTDI firmware expects for all of these. */
+    private async sio(request: number, value: number, index = FTDI_PORT_INDEX): Promise<void> {
+        const device = this.device;
+        if (!device) throw new DmeLinkError('USB device is not open');
+        const result = await device.controlTransferOut({
+            requestType: 'vendor', recipient: 'device', request, value, index,
+        });
+        if (result.status !== 'ok') {
+            throw new DmeLinkError(`FTDI control request 0x${request.toString(16)} failed (${result.status})`);
+        }
+    }
+
+    private async setBaudRate(baudRate: number): Promise<void> {
+        const divisor = FTDI_DIVISORS[baudRate];
+        if (!divisor) {
+            throw new DmeLinkError(
+                `Unsupported baud rate ${baudRate} for the FTDI transport (supported: ` +
+                `${Object.keys(FTDI_DIVISORS).join(', ')})`);
+        }
+        await this.sio(SIO_SET_BAUD_RATE, divisor.value, divisor.index);
+    }
+
+    private async flushReceive(): Promise<void> {
+        await this.sio(SIO_RESET, SIO_RESET_PURGE_RX);
+    }
+
+    async open(): Promise<void> {
+        if (!WebUsbFtdiTransport.isSupported()) {
+            throw new DmeLinkError('WebUSB is not available in this browser (Chrome for Android required).');
+        }
+        const usb = navigator.usb!;
+
+        // A device already granted to this origin first: WebUSB permissions persist, so a returning
+        // user should not have to pick the same cable again. It also has to come before
+        // requestDevice(), while the transient user activation from the tap is still alive.
+        const granted = (await usb.getDevices()).filter(d => d.vendorId === FTDI_VENDOR_ID);
+        // requestDevice's rejection is deliberately NOT wrapped: dismissing the chooser rejects with
+        // NotFoundError, and useDmeLink treats that name as a user cancel rather than a failure.
+        // Wrapping it would turn "changed their mind" into a red error line.
+        const device = granted[0] ?? await usb.requestDevice({ filters: [{ vendorId: FTDI_VENDOR_ID }] });
+        this.device = device;
+        this.deviceGone = false;
+
+        await device.open();
+        if (!device.configuration) await device.selectConfiguration(1);
+
+        this.selectEndpoints();
+        this.assertSupportedChipFamily();
+
+        await device.claimInterface(this.interfaceNumber);
+        usb.addEventListener('disconnect', this.onDisconnect);
+
+        // Order matters: SIO_RESET clears modem-control state, so the DTR/RTS request must follow it.
+        await this.sio(SIO_RESET, SIO_RESET_SIO);
+        await this.sio(SIO_SET_LATENCY_TIMER, FTDI_LATENCY_MS);
+        await this.sio(SIO_SET_FLOW_CTRL, 0, 0x0000 | FTDI_PORT_INDEX); // mode 0 = none, in the high byte
+        await this.setBaudRate(9600);
+        await this.sio(SIO_SET_DATA, FTDI_DATA_8E1);
+        await this.sio(SIO_SET_MODEM_CTRL, FTDI_MODEM_DTR_LOW_RTS_LOW);
+        await this.flushReceive();
+
+        this.clearBuffer();
+        this.pumpError = null;
+        this.skipLineStatusOnce = true;
+        this.pumpActive = true;
+        this.startPump();
+    }
+
+    /** Finds the bulk IN/OUT pair from the descriptors. Endpoint numbers are never hardcoded: they
+     *  are 0x81/0x02 on every FT232R seen so far, but a wrong guess here is a silent dead link. */
+    private selectEndpoints(): void {
+        const device = this.device!;
+        for (const iface of device.configuration?.interfaces ?? []) {
+            const inEp = iface.alternate.endpoints.find(e => e.direction === 'in' && e.type === 'bulk');
+            const outEp = iface.alternate.endpoints.find(e => e.direction === 'out' && e.type === 'bulk');
+            if (inEp && outEp) {
+                this.interfaceNumber = iface.interfaceNumber;
+                this.inEndpoint = inEp.endpointNumber;
+                this.outEndpoint = outEp.endpointNumber;
+                this.packetSize = inEp.packetSize || 64;
+                return;
+            }
+        }
+        throw new DmeLinkError('No bulk endpoint pair found on this USB device — is it really an FTDI cable?');
+    }
+
+    private assertSupportedChipFamily(): void {
+        const version = this.device!.deviceVersionMajor;
+        if (!SUPPORTED_CHIP_VERSIONS.has(version)) {
+            throw new DmeLinkError(
+                `Unsupported FTDI chip (bcdDevice major ${version}). This transport implements the ` +
+                `3 MHz divisor encoding used by FT232AM/BM/R; H-series and FT-X parts clock differently.`);
+        }
+    }
+
+    /**
+     * The read loop.
+     *
+     * Every bulk IN **packet** — not every transfer — is prefixed with two status bytes, so with a
+     * multi-packet transfer the headers are *interior*, not merely at offset 0. Stripping them at
+     * offset 0 only would produce a plausible-looking BIN with two bytes of garbage every 64, which
+     * is the worst failure this design can have: it does not announce itself.
+     *
+     * There is no busy spin to avoid. `transferIn` has no timeout and stays pending until the chip
+     * sends something, and the chip sends a status packet on every latency-timer expiry regardless
+     * of traffic — which is also what makes `pumpActive = false` sufficient to stop this loop within
+     * one latency period, with no transfer to cancel.
+     *
+     * Exactly one transfer is in flight at a time. Queueing several is the usual WebUSB throughput
+     * trick and they almost certainly complete in order — but "almost certainly" reorders a flash
+     * payload, and the OE bit will say empirically whether a second is ever needed.
+     */
+    private startPump(): void {
+        const device = this.device!;
+        this.pumpExited = (async () => {
+            const scratch = new Uint8Array(8 * this.packetSize);
+            while (this.pumpActive) {
+                let result: USBInTransferResult;
+                try {
+                    result = await device.transferIn(this.inEndpoint, 8 * this.packetSize);
+                } catch (e: unknown) {
+                    if (!this.pumpActive) return;
+                    this.latch(this.classifyTransferError(e));
+                    return;
+                }
+                if (!this.pumpActive) return;
+                if (result.status === 'stall') {
+                    try { await device.clearHalt('in', this.inEndpoint); continue; }
+                    catch (e: unknown) { this.latch(this.classifyTransferError(e)); return; }
+                }
+                if (result.status === 'babble') {
+                    this.latch(new FtdiLineError('BabbleError', 'The USB device returned more data than requested'));
+                    return;
+                }
+
+                const view = result.data;
+                if (!view) continue;
+                let payload = 0;
+                let fault: number | null = null;
+                for (let offset = 0; offset + 2 <= view.byteLength; offset += this.packetSize) {
+                    const lineStatus = view.getUint8(offset + 1);
+                    if ((lineStatus & LSR_ANY_ERROR) !== 0 && !this.skipLineStatusOnce) {
+                        fault = lineStatus;
+                        break;
+                    }
+                    const available = Math.min(this.packetSize, view.byteLength - offset) - 2;
+                    for (let i = 0; i < available; i++) scratch[payload++] = view.getUint8(offset + 2 + i);
+                }
+                this.skipLineStatusOnce = false;
+                // Deliver before latching: bytes that arrived cleanly ahead of the fault in the same
+                // transfer are real, and dropping them would desync the frame the link is mid-way
+                // through reading.
+                if (payload > 0) this.receive(scratch.subarray(0, payload));
+                if (fault !== null) { this.latch(this.classifyLineStatus(fault)); return; }
+            }
+        })();
+    }
+
+    /** Maps line-status bits onto the error NAMES the Web Serial backend produces, because
+     *  readExact's message and §9's triage table are both written against those spellings.
+     *  Priority order: a break implies the framing garbage that accompanies it. */
+    private classifyLineStatus(lineStatus: number): Error {
+        if (lineStatus & LSR_BREAK) return new FtdiLineError('BreakError', 'Break received');
+        if (lineStatus & LSR_FRAMING) return new FtdiLineError('FramingError', 'Framing error');
+        if (lineStatus & LSR_PARITY) return new FtdiLineError('ParityError', 'Parity error');
+        return new FtdiLineError('BufferOverrunError', 'Receive buffer overrun');
+    }
+
+    private classifyTransferError(e: unknown): Error {
+        if (this.deviceGone) return new FtdiLineError('NetworkError', 'The device was disconnected');
+        return e instanceof Error ? e : new Error(String(e));
+    }
+
+    async close(): Promise<void> {
+        this.pumpActive = false;
+        this.releaseWaiter();
+        navigator.usb?.removeEventListener('disconnect', this.onDisconnect);
+        try { await this.pumpExited; } catch { }
+        try { await this.device?.releaseInterface(this.interfaceNumber); } catch { }
+        try { await this.device?.close(); } catch { }
+        this.device = null;
+        this.clearBuffer();
+    }
+
+    /**
+     * Changes baud **in place** — one control transfer, no close, no reopen, no restarted pump.
+     *
+     * This is the structural difference the implementation notes call out as forced and
+     * unavoidable: "Web Serial has no in-place baud change, so reopen() must do close() + open().
+     * Every boosted read therefore begins with a port transition that no other DS2 tool produces …
+     * It cannot be removed, only made less disruptive." On this backend it *is* removed, and the app
+     * does exactly what the reference tool does (FT_SetBaudRate on the still-open handle).
+     *
+     * Note what follows from that: there is no control-line symmetry to maintain here. The Web
+     * Serial backend re-de-asserts DTR/RTS after every reopen because its close/open cycle moves
+     * them; nothing moves them here, so they are set once at open() and never touched again.
+     */
+    async reopen(baudRate: number): Promise<void> {
+        if (!this.device) throw new DmeLinkError('USB device is not open');
+        await this.setBaudRate(baudRate);
+        await this.flushReceive();
+        this.clearBuffer();
+        this.pumpError = null;
+        this.skipLineStatusOnce = true;
+    }
+
+    async write(bytes: Uint8Array): Promise<void> {
+        const device = this.device;
+        if (!device) throw new DmeLinkError('USB device is not open');
+        this.timing?.writeStart(performance.now());
+        const result = await device.transferOut(this.outEndpoint, bytes);
+        this.timing?.writeEnd(performance.now());
+        if (result.status !== 'ok') {
+            throw new DmeLinkError(`USB write failed (${result.status})`);
+        }
+    }
+
+    /**
+     * Empties the JS buffer and, unlike the Web Serial backend, also flushes the chip's own FIFO.
+     *
+     * Stays synchronous by contract — `resyncTransport` calls it without awaiting and
+     * `drainUntilQuiet` reads `bufferedLength()` immediately afterwards. The driver flush is
+     * therefore fire-and-forget. That is safe for the reason already documented on the Web Serial
+     * version: purge runs *between* exchanges, under the link's command gate, so there is no
+     * in-flight frame for a late-landing flush to eat. If that invariant ever changes, this becomes
+     * a real hazard rather than a tidy-up.
+     */
+    purge(): void {
+        super.purge();
+        void this.flushReceive().catch(() => { });
+    }
+
+    /**
+     * Clears a latched fault without closing the device.
+     *
+     * Simpler and stronger than the Web Serial equivalent: there is no reader to re-acquire, and the
+     * flush is a real one that reaches the chip's FIFO rather than only the bytes already handed to
+     * us. The 100 ms settle is kept identical, because it is sized to the break/idle condition on
+     * the wire, not to anything about the host API.
+     */
+    async recoverRead(): Promise<void> {
+        if (!this.device) throw new DmeLinkError('USB device is not open');
+        this.pumpActive = false;
+        this.releaseWaiter();
+        try { await this.pumpExited; } catch { }
+        await new Promise(r => setTimeout(r, 100)); // let the break / idle condition settle
+        if (this.deviceGone) {
+            throw new DmeLinkError('The USB device disconnected — unplug and replug the cable, then reconnect.');
+        }
+        await this.flushReceive();
+        this.clearBuffer();
+        this.pumpError = null;
+        this.skipLineStatusOnce = true;
+        this.pumpActive = true;
+        this.startPump();
+    }
+}


### PR DESCRIPTION
## なぜ

**WebUSB は実装されていませんでした** — `navigator.usb` はコードベースに一箇所も存在せず、ハードウェアアクセスは Web Serial のみでした。

Android で動かないのは移植していなかったからではなく、**API レベルで到達できない**からです。Chrome for Android 138+ は `navigator.serial` を公開していますが、MDN の互換データの注記どおり *"Serial ports are only available if they're provided by Bluetooth RFCOMM serial port emulation."* — **Bluetooth SPP のポートしか列挙されず、USB の K+DCAN ケーブルは見えません。**

そのため現状の Android は「未対応」ですらなく、**対応しているように見えて黙って失敗する**状態でした：`'serial' in navigator` が true を返し、利用者は権限プロンプトをタップし、空のポートピッカーを見ることになります。

`docs/implementation-notes.md` は WebUSB を一度「対象外」としていましたが、その根拠は Windows 固有（Zadig で `ftdibus.sys` を差し替えると COM ポートが消え INPA/Tool32/ISTA が壊れる）で、置き換えるべき VCP ドライバが存在しない Android には当てはまりません。**デスクトップは Web Serial のまま一切変更していません。**

## 変更内容

### トランスポート境界の抽出

`webSerialTransport.ts` は当初から「reference app の `IByteTransport` contract を写したもの」と書かれていましたが、その TypeScript インタフェースは存在しませんでした。これを実体化し、バッファ／駐機ワーカ／`readExact` の半分を両バックエンド共有の `BufferedByteTransport` へ移しています。

**コピーではなく移動**です。この待機セマンティクスはこの層で最も繊細な部分で、38400 の調査もここに懸かっていました。2 つの複製は必ずドリフトします。移動が純粋な切り出しであることは機械的に検証済み（`readExact` ほか 3 メソッドがバイト単位で同一）。

`WebSerialDmeLink` は `ByteTransport` を保持するだけで、**21 箇所のトランスポート呼び出しはすべて無変更**、DS2 層はどちらのバックエンドか知りません。

### FTDI バックエンドで改善した点

ノートが「動かせない」と記録していた 3 点が解消します：

- **ボーレートをその場で変更** — `SET_BAUD_RATE` 1 回のみ。§9 が「forced」と呼び、boosted rate の失敗の原因と見ていた close/open のポート遷移が消えます
- **`purge()` がチップの FIFO に届く** — 従来は JS バッファを空にするだけ
- **読み取りポンプの停止にキャンセルが不要** — ステータスハートビートが 1 レイテンシ周期内に転送を解決するため

### 悪化する点（重要）

Web Serial ではブラウザプロセスが我々と独立にエンドポイントを 4096 バイトのパイプへ排出しますが、**WebUSB では我々の読み取りループだけが 256 バイトの FIFO を、React と同じスレッド上で排出します。** 9600 で約 267 ms の余裕しかありません。

無言の破損ではなく **OE ビットとして検出される**ため既存のリトライ機構が処理できますが、これが「転送を 1 つだけ in-flight に保つ」理由であり、**レイテンシタイマを 2〜4 ms ではなくチップ既定の 16 ms に置く**理由でもあります。ノートの 2〜4 ms という予測はブラウザが起床を吸収する前提のもので、ここには当てはまりません（1 ms なら毎秒 1000 回のメインスレッド起床）。

### ステータスヘッダ

バルク IN の**各パケット**先頭に 2 バイトのステータスが付き、マルチパケット転送では**内部にも**現れます。offset 0 だけ剥がすと、64 バイトごとに 2 バイトのゴミが入った**それらしく見える 64 KB の BIN** ができます。実車での受け入れテストを「デスクトップ読み取りとのバイト比較」にしているのはこのためです。

回線ステータスは Web Serial のエラー**名**（`BreakError` / `FramingError` / `ParityError` / `BufferOverrunError` / `NetworkError`）に写像しています。`readExact` が名前を出力し、§12 のトリアージ表がその綴りで書かれているためです。

### 分周テーブル

汎用コンバータではなく**監査済みの定数 3 つ**（`DS2_SELECTABLE_BAUDS` がちょうどこの 3 つで、ds2.ts が増えない理由を詳述しているため）。値は 9600 → `0x4138`、38400 → `0xC04E`、125000 → `0x0018`、いずれも誤差ゼロ。前 2 つは FTDI の AN232B-05 公表値と一致します。

**モジュールロード時に再計算して検証**しています。テストランナーが存在しない本プロジェクトで、誤った定数を全環境（本番含む）で落とせる唯一の機構です。定数を故意に壊してビルドが失敗することを確認済み：

```
Error: FTDI divisor table wrong for 9600: table says 0x4139/0, computed 0x4138/0
```

### 既存バグの修正（Android とは無関係）

`isSupported()` はレンダー中に評価されており、静的プリレンダー時に false を返して **`out/index.html` に「Web Serial API not available in this browser」を焼き込んでいました**。デスクトップ Chrome の利用者全員が、ハイドレーション前に 1 フレームこの誤った警告を見ていたことになります。ビルド出力の実測で確認し、修正後は 0 件です。

通知は英語ベタ書きで既存の JA/EN ルールも迂回していたため、`dialogText()` 経由に載せ替えました。

### Android での長時間書き込み

`beforeunload` は Chrome for Android での発火が不確実で、これより強い API は存在しません。3 方向から補っています：`useScreenWakeLock`（自然に起きる中断＝画面消灯を防ぐ）、`useHiddenWitness`（バックグラウンド化を記録し、失敗をケーブル不良に見せない）、`writeConfirm` の Android 専用文言。

### モバイル UI

ご指摘のダイアログ幅・ヘッダーに加え、サイズ調整では直らない 3 点を修正：

- `h-screen` → `h-[100dvh]` — Android の `100vh` は chrome が引っ込んだ**最大**ビューポートで、スクロールしない設計のため WRITE の並ぶ最下部アクション行が URL バーの裏に隠れます
- **ログのタッチパン** — 共有ウィンドウのパンは `wheel` 専用で、指ドラッグは `dragmode: 'pan'` の Plotly に落ちていました。これは `LogTimeSeriesChart.tsx` のコメントが「チャートだけ動いて表が別スライスを表示し続ける desync」として明示的に避けている挙動そのもので、タッチでは保護が外れていました
- **ヘッダーの FLASH** — 情報帯は `overflow-hidden` で、コメント自身が「最初に切れるのはここ」と書いています。切れる先頭にいる FLASH は表示ではなく**ボタン**で、フラッシュカウンタダイアログへの唯一の入口です。900px 未満では VIN/AIF/SW を隠して FLASH を残します
- 破壊的ボタンのタップ標的は `py-3 -my-3` で拡大 — 46px の予約高とハブの不動性を壊さないため

## 検証

- `npx tsc --noEmit` クリーン
- `npm run lint` — **ベースラインと完全に同一**（49 problems / 25 errors、いずれも既存）
- `npm run build` 成功、`/usb-check` も静的出力
- 分周値を独立に再計算して一致を確認
- モジュールロード検証が実際にビルドを落とすことを確認
- 移動したメソッドが元とバイト単位で同一であることを確認
- プリレンダーへの誤警告焼き込みが 0 件になったことをビルド出力で確認

## まだ検証していないこと

**実機では一切動かしていません。** 電話も、ケーブルも、車も通していません。

`/usb-check` は独立したベンチ用ページ（link 層から何も import しないため、検証対象を壊すことも壊されることもありません）で、レビューでは答えられない問いを順に潰します。**最初の 1 つ — Chrome for Android が FTDI インタフェースを claim できるか — が他のすべてを規定します。** Android カーネルの `ftdi_sio` が掴んでいて Chrome が detach できなければ、この PR の残りは無意味です。

ベンチには **TX–RX を短絡した素の FT232R ブレークアウト**が必要です。K+DCAN ケーブルは机上では自己エコーしません（K-line のプルアップは車両側の OBD 16 番ピンから来るため）。

実車では: 9600 での識別 → 64 KB 読み取りを**デスクトップ読み取りとバイト比較** → データログ → **最後に**書き込み、の順を想定しています。

なお 38400 について、ポート遷移が消えるので再試験は安価になりますが、**速度改善は見込まないでください**。§9 の FINAL がレイテンシタイマ・受信バッファ・DTR/RTS・ホスト側オーバーヘッドをすべて実測で棄却し、残差を物理要因と結論づけています。

---
_Generated by [Claude Code](https://claude.ai/code/session_011UumHUiRnUZRLjBCXENuyw)_